### PR TITLE
Add auth pages, layout, routes and styles

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,14 +1,21 @@
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
+import { AuthLayout } from "./components/layout/AuthLayout";
 import { DashboardLayout } from "./components/layout/DashboardLayout";
 import { AssetsPage } from "./pages/AssetsPage";
 import { HomePage } from "./pages/HomePage";
+import { LoginPage } from "./pages/LoginPage";
 import { PortfoliosPage } from "./pages/PortfoliosPage";
+import { RegisterPage } from "./pages/RegisterPage";
 import { SettingsPage } from "./pages/SettingsPage";
 
 export function App() {
   return (
     <BrowserRouter>
       <Routes>
+        <Route element={<AuthLayout />}>
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/register" element={<RegisterPage />} />
+        </Route>
         <Route element={<DashboardLayout />}>
           <Route path="/" element={<HomePage />} />
           <Route path="/portfolios" element={<PortfoliosPage />} />

--- a/frontend/src/components/layout/AuthLayout.tsx
+++ b/frontend/src/components/layout/AuthLayout.tsx
@@ -1,0 +1,13 @@
+import { Outlet } from "react-router-dom";
+
+export function AuthLayout() {
+  return (
+    <div className="auth-shell">
+      <section className="auth-card">
+        <h1>Portfolio Tracker</h1>
+        <p>Autentifica-te sau creeaza un cont nou.</p>
+        <Outlet />
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,94 @@
+import { useMemo, useState } from "react";
+import type { FormEvent } from "react";
+import { Link } from "react-router-dom";
+import { submitLogin } from "../services/auth";
+
+type LoginFields = {
+  email: string;
+  password: string;
+};
+
+type LoginErrors = Partial<Record<keyof LoginFields, string>>;
+
+function validateLogin(fields: LoginFields): LoginErrors {
+  const errors: LoginErrors = {};
+
+  if (!fields.email.trim()) {
+    errors.email = "Email este obligatoriu.";
+  } else if (!fields.email.includes("@")) {
+    errors.email = "Email invalid.";
+  }
+
+  if (!fields.password) {
+    errors.password = "Parola este obligatorie.";
+  } else if (fields.password.length < 8) {
+    errors.password = "Parola trebuie sa aiba minim 8 caractere.";
+  }
+
+  return errors;
+}
+
+export function LoginPage() {
+  const [fields, setFields] = useState<LoginFields>({ email: "", password: "" });
+  const [errors, setErrors] = useState<LoginErrors>({});
+  const [statusMessage, setStatusMessage] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const hasErrors = useMemo(() => Object.keys(errors).length > 0, [errors]);
+
+  const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const nextErrors = validateLogin(fields);
+    setErrors(nextErrors);
+    setStatusMessage("");
+
+    if (Object.keys(nextErrors).length > 0) {
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      await submitLogin(fields);
+      setStatusMessage("Formular trimis. Conectarea la backend va fi activata in pasul urmator.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form className="auth-form" onSubmit={onSubmit} noValidate>
+      <h2>Login</h2>
+
+      <label htmlFor="login-email">Email</label>
+      <input
+        id="login-email"
+        name="email"
+        type="email"
+        value={fields.email}
+        onChange={(event) => setFields((prev) => ({ ...prev, email: event.target.value }))}
+      />
+      {errors.email && <p className="field-error">{errors.email}</p>}
+
+      <label htmlFor="login-password">Parola</label>
+      <input
+        id="login-password"
+        name="password"
+        type="password"
+        value={fields.password}
+        onChange={(event) => setFields((prev) => ({ ...prev, password: event.target.value }))}
+      />
+      {errors.password && <p className="field-error">{errors.password}</p>}
+
+      <button type="submit" disabled={isSubmitting}>
+        {isSubmitting ? "Se trimite..." : "Intra in cont"}
+      </button>
+
+      {statusMessage && <p className="field-success">{statusMessage}</p>}
+      {hasErrors && <p className="field-error">Corecteaza campurile marcate mai sus.</p>}
+
+      <p className="auth-switch">
+        Nu ai cont? <Link to="/register">Creeaza cont</Link>
+      </p>
+    </form>
+  );
+}

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,0 +1,137 @@
+import { useMemo, useState } from "react";
+import type { FormEvent } from "react";
+import { Link } from "react-router-dom";
+import { submitRegister } from "../services/auth";
+
+type RegisterFields = {
+  fullName: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+};
+
+type RegisterErrors = Partial<Record<keyof RegisterFields, string>>;
+
+function validateRegister(fields: RegisterFields): RegisterErrors {
+  const errors: RegisterErrors = {};
+
+  if (!fields.fullName.trim()) {
+    errors.fullName = "Numele complet este obligatoriu.";
+  }
+
+  if (!fields.email.trim()) {
+    errors.email = "Email este obligatoriu.";
+  } else if (!fields.email.includes("@")) {
+    errors.email = "Email invalid.";
+  }
+
+  if (!fields.password) {
+    errors.password = "Parola este obligatorie.";
+  } else if (fields.password.length < 8) {
+    errors.password = "Parola trebuie sa aiba minim 8 caractere.";
+  }
+
+  if (!fields.confirmPassword) {
+    errors.confirmPassword = "Confirmarea parolei este obligatorie.";
+  } else if (fields.confirmPassword !== fields.password) {
+    errors.confirmPassword = "Parolele nu coincid.";
+  }
+
+  return errors;
+}
+
+export function RegisterPage() {
+  const [fields, setFields] = useState<RegisterFields>({
+    fullName: "",
+    email: "",
+    password: "",
+    confirmPassword: "",
+  });
+  const [errors, setErrors] = useState<RegisterErrors>({});
+  const [statusMessage, setStatusMessage] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const hasErrors = useMemo(() => Object.keys(errors).length > 0, [errors]);
+
+  const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const nextErrors = validateRegister(fields);
+    setErrors(nextErrors);
+    setStatusMessage("");
+
+    if (Object.keys(nextErrors).length > 0) {
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      await submitRegister({
+        fullName: fields.fullName,
+        email: fields.email,
+        password: fields.password,
+      });
+      setStatusMessage("Formular trimis. Conectarea la backend va fi activata in pasul urmator.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form className="auth-form" onSubmit={onSubmit} noValidate>
+      <h2>Register</h2>
+
+      <label htmlFor="register-name">Nume complet</label>
+      <input
+        id="register-name"
+        name="fullName"
+        type="text"
+        value={fields.fullName}
+        onChange={(event) => setFields((prev) => ({ ...prev, fullName: event.target.value }))}
+      />
+      {errors.fullName && <p className="field-error">{errors.fullName}</p>}
+
+      <label htmlFor="register-email">Email</label>
+      <input
+        id="register-email"
+        name="email"
+        type="email"
+        value={fields.email}
+        onChange={(event) => setFields((prev) => ({ ...prev, email: event.target.value }))}
+      />
+      {errors.email && <p className="field-error">{errors.email}</p>}
+
+      <label htmlFor="register-password">Parola</label>
+      <input
+        id="register-password"
+        name="password"
+        type="password"
+        value={fields.password}
+        onChange={(event) => setFields((prev) => ({ ...prev, password: event.target.value }))}
+      />
+      {errors.password && <p className="field-error">{errors.password}</p>}
+
+      <label htmlFor="register-confirm-password">Confirma parola</label>
+      <input
+        id="register-confirm-password"
+        name="confirmPassword"
+        type="password"
+        value={fields.confirmPassword}
+        onChange={(event) =>
+          setFields((prev) => ({ ...prev, confirmPassword: event.target.value }))
+        }
+      />
+      {errors.confirmPassword && <p className="field-error">{errors.confirmPassword}</p>}
+
+      <button type="submit" disabled={isSubmitting}>
+        {isSubmitting ? "Se trimite..." : "Creeaza cont"}
+      </button>
+
+      {statusMessage && <p className="field-success">{statusMessage}</p>}
+      {hasErrors && <p className="field-error">Corecteaza campurile marcate mai sus.</p>}
+
+      <p className="auth-switch">
+        Ai deja cont? <Link to="/login">Mergi la login</Link>
+      </p>
+    </form>
+  );
+}

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,0 +1,17 @@
+import type { LoginPayload, RegisterPayload } from "../types/auth";
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+export async function submitLogin(_payload: LoginPayload): Promise<void> {
+  // TODO: Inlocuieste cu apel backend: POST /auth/login
+  await wait(500);
+}
+
+export async function submitRegister(_payload: RegisterPayload): Promise<void> {
+  // TODO: Inlocuieste cu apel backend: POST /auth/register
+  await wait(500);
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -13,6 +13,85 @@ body {
   margin: 0;
 }
 
+.auth-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 16px;
+}
+
+.auth-card {
+  width: 100%;
+  max-width: 440px;
+  background: #ffffff;
+  border: 1px solid #cbd5e1;
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.08);
+}
+
+.auth-card h1 {
+  margin: 0 0 6px;
+}
+
+.auth-card > p {
+  margin: 0 0 16px;
+  color: #334155;
+}
+
+.auth-form {
+  display: grid;
+  gap: 8px;
+}
+
+.auth-form h2 {
+  margin: 0 0 4px;
+}
+
+.auth-form label {
+  font-weight: 600;
+}
+
+.auth-form input {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 10px 12px;
+  font: inherit;
+}
+
+.auth-form button {
+  margin-top: 8px;
+  border: none;
+  border-radius: 8px;
+  padding: 10px 12px;
+  background: #0f172a;
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.auth-form button:disabled {
+  opacity: 0.7;
+  cursor: wait;
+}
+
+.field-error {
+  margin: 0;
+  color: #b91c1c;
+  font-size: 0.92rem;
+}
+
+.field-success {
+  margin: 0;
+  color: #166534;
+  font-size: 0.92rem;
+}
+
+.auth-switch {
+  margin: 6px 0 0;
+  color: #334155;
+}
+
 .dashboard-shell {
   min-height: 100vh;
   display: grid;

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,0 +1,10 @@
+export type LoginPayload = {
+  email: string;
+  password: string;
+};
+
+export type RegisterPayload = {
+  email: string;
+  password: string;
+  fullName: string;
+};


### PR DESCRIPTION
Introduce authentication UI and wiring: add AuthLayout, LoginPage and RegisterPage (client-side validation with Romanian messages), stubbed submitLogin/submitRegister in services/auth.ts, and auth types in types/auth.ts. Update App.tsx to register /login and /register routes inside the new AuthLayout. Add auth-specific styles to global.css for the auth shell, card and form. Services include TODOs to replace stubs with real backend calls — this change prepares the frontend for authentication flows and basic UX.

Closed #20 