### PR TITLE
Add portfolios UI, API client, and backend fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .env
+# JetBrains (PyCharm / IntelliJ) — setări locale, nu în repo
+.idea/
+
 __pycache__/
 *.py[cod]
 venv/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,4 +20,5 @@ USER appuser
 
 EXPOSE 8000
 
-CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Migrații la pornire (fără fișier .sh — evită CRLF pe Windows care rupe shebang-ul în Linux)
+ENTRYPOINT ["sh", "-c", "set -e && cd /app && python -m alembic -c backend/alembic.ini upgrade head && exec python -m uvicorn backend.main:app --host 0.0.0.0 --port 8000"]

--- a/backend/alembic/versions/eec4b8a12d3f_ensure_users_hashed_password.py
+++ b/backend/alembic/versions/eec4b8a12d3f_ensure_users_hashed_password.py
@@ -1,25 +1,29 @@
-"""Add hashed_password
+"""Ensure users.hashed_password exists (repair empty 4579 upgrade)
 
-Revision ID: 4579ad263afd
-Revises: 373d648251a9
-Create Date: 2026-04-02 14:47:36.909243
+Revision ID: eec4b8a12d3f
+Revises: 4579ad263afd
+Create Date: 2026-04-20
 
 """
 from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy import inspect
 
 
-# revision identifiers, used by Alembic.
-revision: str = '4579ad263afd'
-down_revision: Union[str, Sequence[str], None] = '373d648251a9'
+revision: str = "eec4b8a12d3f"
+down_revision: Union[str, Sequence[str], None] = "4579ad263afd"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    """Upgrade schema."""
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    columns = [c["name"] for c in inspector.get_columns("users")]
+    if "hashed_password" in columns:
+        return
     op.add_column(
         "users",
         sa.Column(
@@ -33,5 +37,4 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    """Downgrade schema."""
-    op.drop_column("users", "hashed_password")
+    pass

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from .core.config import settings
 from .db import init_db, close_db
 from .api.routes.auth import router as auth_router
@@ -10,6 +11,21 @@ from .api.routes.transactions import router as transactions_router
 app = FastAPI(
     title=settings.app_name,
     version="1.0.0"
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[
+        "http://localhost:5173",
+        "http://127.0.0.1:5173",
+        "http://localhost:5174",
+        "http://127.0.0.1:5174",
+    ],
+    # Orice port pe localhost / 127.0.0.1 (Vite poate folosi 5173, 5174, etc.)
+    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 app.include_router(auth_router)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { DashboardLayout } from "./components/layout/DashboardLayout";
 import { AssetsPage } from "./pages/AssetsPage";
 import { HomePage } from "./pages/HomePage";
 import { LoginPage } from "./pages/LoginPage";
+import { PortfolioHoldingsPage } from "./pages/PortfolioHoldingsPage";
 import { PortfoliosPage } from "./pages/PortfoliosPage";
 import { RegisterPage } from "./pages/RegisterPage";
 import { SettingsPage } from "./pages/SettingsPage";
@@ -19,6 +20,7 @@ export function App() {
         <Route element={<DashboardLayout />}>
           <Route path="/" element={<HomePage />} />
           <Route path="/portfolios" element={<PortfoliosPage />} />
+          <Route path="/portfolios/:portfolioId/holdings" element={<PortfolioHoldingsPage />} />
           <Route path="/assets" element={<AssetsPage />} />
           <Route path="/settings" element={<SettingsPage />} />
         </Route>

--- a/frontend/src/lib/apiBase.ts
+++ b/frontend/src/lib/apiBase.ts
@@ -1,0 +1,3 @@
+export function getApiBaseUrl(): string {
+  return import.meta.env.VITE_API_BASE_URL?.toString() ?? "http://localhost:8000";
+}

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -1,0 +1,23 @@
+import { getAccessToken } from "./authToken";
+import { getApiBaseUrl } from "./apiBase";
+
+export type ApiFetchOptions = RequestInit & {
+  auth?: boolean;
+};
+
+export async function apiFetch(path: string, options: ApiFetchOptions = {}): Promise<Response> {
+  const { auth = true, headers: initHeaders, ...rest } = options;
+  const headers = new Headers(initHeaders);
+
+  if (auth) {
+    const token = getAccessToken();
+    if (token) {
+      headers.set("Authorization", `Bearer ${token}`);
+    }
+  }
+
+  return fetch(`${getApiBaseUrl()}${path}`, {
+    ...rest,
+    headers,
+  });
+}

--- a/frontend/src/lib/apiError.ts
+++ b/frontend/src/lib/apiError.ts
@@ -1,0 +1,29 @@
+export async function readApiErrorMessage(response: Response): Promise<string> {
+  try {
+    const data: unknown = await response.json();
+    if (
+      typeof data === "object" &&
+      data !== null &&
+      "detail" in data &&
+      data.detail !== undefined
+    ) {
+      const detail = (data as { detail: unknown }).detail;
+      if (typeof detail === "string") {
+        return detail;
+      }
+      if (Array.isArray(detail)) {
+        return detail
+          .map((item) => {
+            if (typeof item === "object" && item !== null && "msg" in item) {
+              return String((item as { msg: unknown }).msg);
+            }
+            return JSON.stringify(item);
+          })
+          .join("; ");
+      }
+    }
+  } catch {
+    // ignore JSON parse errors
+  }
+  return `Request failed (${response.status})`;
+}

--- a/frontend/src/lib/authToken.ts
+++ b/frontend/src/lib/authToken.ts
@@ -1,0 +1,13 @@
+const ACCESS_TOKEN_KEY = "portfolio_tracker_access_token";
+
+export function getAccessToken(): string | null {
+  return localStorage.getItem(ACCESS_TOKEN_KEY);
+}
+
+export function setAccessToken(token: string): void {
+  localStorage.setItem(ACCESS_TOKEN_KEY, token);
+}
+
+export function clearAccessToken(): void {
+  localStorage.removeItem(ACCESS_TOKEN_KEY);
+}

--- a/frontend/src/pages/AssetsPage.tsx
+++ b/frontend/src/pages/AssetsPage.tsx
@@ -1,8 +1,203 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { FormEvent } from "react";
+import { Link } from "react-router-dom";
+import { getAccessToken } from "../lib/authToken";
+import { createAsset, listAssets } from "../services/assets";
+import type { AssetRead } from "../types/asset";
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
 export function AssetsPage() {
+  const [items, setItems] = useState<AssetRead[]>([]);
+  const [filter, setFilter] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [listError, setListError] = useState("");
+
+  const [symbol, setSymbol] = useState("");
+  const [name, setName] = useState("");
+  const [assetType, setAssetType] = useState("");
+  const [currency, setCurrency] = useState("");
+  const [createError, setCreateError] = useState("");
+  const [creating, setCreating] = useState(false);
+
+  const token = getAccessToken();
+  const needsAuth = !token;
+
+  const load = useCallback(async () => {
+    if (needsAuth) return;
+    setListError("");
+    setLoading(true);
+    try {
+      const data = await listAssets();
+      setItems(data);
+    } catch (error) {
+      setListError(error instanceof Error ? error.message : "Nu am putut incarca activele.");
+    } finally {
+      setLoading(false);
+    }
+  }, [needsAuth]);
+
+  useEffect(() => {
+    if (needsAuth) {
+      setItems([]);
+      setLoading(false);
+      return;
+    }
+    void load();
+  }, [needsAuth, load]);
+
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter(
+      (a) =>
+        a.symbol.toLowerCase().includes(q) ||
+        (a.name?.toLowerCase().includes(q) ?? false) ||
+        (a.asset_type?.toLowerCase().includes(q) ?? false) ||
+        (a.currency?.toLowerCase().includes(q) ?? false),
+    );
+  }, [items, filter]);
+
+  const onCreate = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setCreateError("");
+    if (!symbol.trim()) {
+      setCreateError("Simbolul este obligatoriu.");
+      return;
+    }
+    try {
+      setCreating(true);
+      await createAsset({
+        symbol: symbol.trim(),
+        name: name.trim() || null,
+        asset_type: assetType.trim() || null,
+        currency: currency.trim() || null,
+      });
+      setSymbol("");
+      setName("");
+      setAssetType("");
+      setCurrency("");
+      await load();
+    } catch (error) {
+      setCreateError(error instanceof Error ? error.message : "Crearea activului a esuat.");
+    } finally {
+      setCreating(false);
+    }
+  };
+
   return (
-    <section className="card">
-      <h3>Assets</h3>
-      <p>Pagina pregatita pentru catalogul de active si filtrare.</p>
-    </section>
+    <div className="portfolios-page">
+      <section className="card">
+        <h3>Assets</h3>
+        <p className="muted">
+          Catalog de active folosit la <Link to="/portfolios">portofolii</Link> si detineri. Selectia in
+          pagina de detineri foloseste lista de mai jos (cu filtru).
+        </p>
+
+        {needsAuth && (
+          <p className="field-error">
+            <Link to="/login">Autentifica-te</Link> pentru a gestiona activele.
+          </p>
+        )}
+
+        {listError && <p className="field-error">{listError}</p>}
+
+        <form className="portfolio-form" onSubmit={onCreate}>
+          <h4 className="subsection-title">Adauga activ</h4>
+          <label htmlFor="asset-symbol">Simbol</label>
+          <input
+            id="asset-symbol"
+            value={symbol}
+            onChange={(e) => setSymbol(e.target.value)}
+            disabled={needsAuth || creating}
+            placeholder="ex: AAPL, BTC"
+          />
+          {createError && <p className="field-error">{createError}</p>}
+
+          <label htmlFor="asset-name">Nume (optional)</label>
+          <input
+            id="asset-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            disabled={needsAuth || creating}
+          />
+
+          <label htmlFor="asset-type">Tip (optional)</label>
+          <input
+            id="asset-type"
+            value={assetType}
+            onChange={(e) => setAssetType(e.target.value)}
+            disabled={needsAuth || creating}
+            placeholder="stock / crypto"
+          />
+
+          <label htmlFor="asset-currency">Moneda (optional)</label>
+          <input
+            id="asset-currency"
+            value={currency}
+            onChange={(e) => setCurrency(e.target.value)}
+            disabled={needsAuth || creating}
+            placeholder="USD"
+          />
+
+          <button type="submit" disabled={needsAuth || creating} className="btn-primary">
+            {creating ? "Se creeaza..." : "Adauga activ"}
+          </button>
+        </form>
+      </section>
+
+      <section className="card">
+        <h4 className="subsection-title">Lista active</h4>
+        <label htmlFor="assets-filter" className="sr-only">
+          Filtreaza
+        </label>
+        <input
+          id="assets-filter"
+          type="search"
+          className="filter-input"
+          placeholder="Filtreaza dupa simbol, nume, tip..."
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          disabled={needsAuth}
+        />
+
+        {loading ? (
+          <p className="muted">Se incarca...</p>
+        ) : filtered.length === 0 ? (
+          <p className="muted">{items.length === 0 ? "Nu exista inca active." : "Niciun rezultat la filtru."}</p>
+        ) : (
+          <div className="table-wrap">
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th>Simbol</th>
+                  <th>Nume</th>
+                  <th>Tip</th>
+                  <th>Moneda</th>
+                  <th>Actualizat</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((a) => (
+                  <tr key={a.id}>
+                    <td>{a.symbol}</td>
+                    <td className="cell-muted">{a.name || "—"}</td>
+                    <td className="cell-muted">{a.asset_type || "—"}</td>
+                    <td className="cell-muted">{a.currency || "—"}</td>
+                    <td className="cell-muted">{formatDate(a.updated_at)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
   );
 }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import type { FormEvent } from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import { setAccessToken } from "../lib/authToken";
 import { submitLogin } from "../services/auth";
 
 type LoginFields = {
@@ -29,9 +30,15 @@ function validateLogin(fields: LoginFields): LoginErrors {
 }
 
 export function LoginPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const registered = Boolean(
+    (location.state as { registered?: boolean } | null)?.registered,
+  );
   const [fields, setFields] = useState<LoginFields>({ email: "", password: "" });
   const [errors, setErrors] = useState<LoginErrors>({});
   const [statusMessage, setStatusMessage] = useState("");
+  const [apiError, setApiError] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const hasErrors = useMemo(() => Object.keys(errors).length > 0, [errors]);
@@ -41,6 +48,7 @@ export function LoginPage() {
     const nextErrors = validateLogin(fields);
     setErrors(nextErrors);
     setStatusMessage("");
+    setApiError("");
 
     if (Object.keys(nextErrors).length > 0) {
       return;
@@ -48,8 +56,12 @@ export function LoginPage() {
 
     try {
       setIsSubmitting(true);
-      await submitLogin(fields);
-      setStatusMessage("Formular trimis. Conectarea la backend va fi activata in pasul urmator.");
+      const token = await submitLogin(fields);
+      setAccessToken(token.access_token);
+      setStatusMessage("Autentificare reusita.");
+      navigate("/", { replace: true });
+    } catch (error) {
+      setApiError(error instanceof Error ? error.message : "Login esuat.");
     } finally {
       setIsSubmitting(false);
     }
@@ -58,6 +70,10 @@ export function LoginPage() {
   return (
     <form className="auth-form" onSubmit={onSubmit} noValidate>
       <h2>Login</h2>
+
+      {registered && (
+        <p className="field-success">Cont creat. Autentifica-te cu email si parola.</p>
+      )}
 
       <label htmlFor="login-email">Email</label>
       <input
@@ -84,6 +100,7 @@ export function LoginPage() {
       </button>
 
       {statusMessage && <p className="field-success">{statusMessage}</p>}
+      {apiError && <p className="field-error">{apiError}</p>}
       {hasErrors && <p className="field-error">Corecteaza campurile marcate mai sus.</p>}
 
       <p className="auth-switch">

--- a/frontend/src/pages/PortfolioHoldingsPage.tsx
+++ b/frontend/src/pages/PortfolioHoldingsPage.tsx
@@ -1,0 +1,392 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { FormEvent } from "react";
+import { Link, useParams } from "react-router-dom";
+import { getAccessToken } from "../lib/authToken";
+import { listAssets } from "../services/assets";
+import {
+  createHolding,
+  deleteHolding,
+  listHoldings,
+  updateHolding,
+} from "../services/holdings";
+import type { AssetRead } from "../types/asset";
+import type { HoldingRead } from "../types/holding";
+
+function formatDec(v: string | number | null | undefined): string {
+  if (v === null || v === undefined) return "—";
+  return String(v);
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+export function PortfolioHoldingsPage() {
+  const { portfolioId: portfolioIdParam } = useParams<{ portfolioId: string }>();
+  const portfolioId = Number(portfolioIdParam);
+  const idValid = Number.isInteger(portfolioId) && portfolioId > 0;
+
+  const [holdings, setHoldings] = useState<HoldingRead[]>([]);
+  const [assets, setAssets] = useState<AssetRead[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [listError, setListError] = useState("");
+  const [assetsError, setAssetsError] = useState("");
+
+  const [assetFilter, setAssetFilter] = useState("");
+  const [selectedAssetId, setSelectedAssetId] = useState("");
+  const [newQty, setNewQty] = useState("");
+  const [newAvgCost, setNewAvgCost] = useState("");
+  const [createError, setCreateError] = useState("");
+  const [creating, setCreating] = useState(false);
+
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editQty, setEditQty] = useState("");
+  const [editAvgCost, setEditAvgCost] = useState("");
+  const [editError, setEditError] = useState("");
+  const [savingEdit, setSavingEdit] = useState(false);
+  const [actionError, setActionError] = useState("");
+
+  const token = getAccessToken();
+  const needsAuth = !token;
+
+  const assetById = useMemo(() => {
+    const m = new Map<number, AssetRead>();
+    for (const a of assets) m.set(a.id, a);
+    return m;
+  }, [assets]);
+
+  const filteredAssets = useMemo(() => {
+    const q = assetFilter.trim().toLowerCase();
+    if (!q) return assets;
+    return assets.filter(
+      (a) =>
+        a.symbol.toLowerCase().includes(q) ||
+        (a.name?.toLowerCase().includes(q) ?? false) ||
+        (a.asset_type?.toLowerCase().includes(q) ?? false),
+    );
+  }, [assets, assetFilter]);
+
+  const loadHoldings = useCallback(async () => {
+    if (!idValid || needsAuth) return;
+    setListError("");
+    setLoading(true);
+    try {
+      const data = await listHoldings(portfolioId);
+      setHoldings(data);
+    } catch (error) {
+      setListError(error instanceof Error ? error.message : "Nu am putut incarca detinerile.");
+    } finally {
+      setLoading(false);
+    }
+  }, [idValid, needsAuth, portfolioId]);
+
+  const loadAssets = useCallback(async () => {
+    if (needsAuth) return;
+    setAssetsError("");
+    try {
+      const data = await listAssets();
+      setAssets(data);
+    } catch (error) {
+      setAssetsError(error instanceof Error ? error.message : "Nu am putut incarca activele.");
+    }
+  }, [needsAuth]);
+
+  useEffect(() => {
+    if (!idValid || needsAuth) {
+      setHoldings([]);
+      setLoading(false);
+      return;
+    }
+    void loadHoldings();
+  }, [idValid, needsAuth, loadHoldings]);
+
+  useEffect(() => {
+    if (needsAuth) {
+      setAssets([]);
+      return;
+    }
+    void loadAssets();
+  }, [needsAuth, loadAssets]);
+
+  const onCreate = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setCreateError("");
+    setActionError("");
+    const assetId = Number(selectedAssetId);
+    if (!Number.isInteger(assetId) || assetId <= 0) {
+      setCreateError("Selecteaza un activ.");
+      return;
+    }
+    if (!newQty.trim() || Number(newQty) < 0) {
+      setCreateError("Cantitatea trebuie sa fie >= 0.");
+      return;
+    }
+    try {
+      setCreating(true);
+      await createHolding(portfolioId, {
+        portfolio_id: portfolioId,
+        asset_id: assetId,
+        quantity: newQty.trim(),
+        avg_cost: newAvgCost.trim() ? newAvgCost.trim() : null,
+      });
+      setNewQty("");
+      setNewAvgCost("");
+      setSelectedAssetId("");
+      await loadHoldings();
+    } catch (error) {
+      setCreateError(error instanceof Error ? error.message : "Crearea detinerii a esuat.");
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const startEdit = (h: HoldingRead) => {
+    setEditingId(h.id);
+    setEditQty(String(h.quantity));
+    setEditAvgCost(h.avg_cost !== null && h.avg_cost !== undefined ? String(h.avg_cost) : "");
+    setEditError("");
+    setActionError("");
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setEditQty("");
+    setEditAvgCost("");
+    setEditError("");
+  };
+
+  const onSaveEdit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (editingId === null) return;
+    setEditError("");
+    setActionError("");
+    if (!editQty.trim() || Number(editQty) < 0) {
+      setEditError("Cantitatea trebuie sa fie >= 0.");
+      return;
+    }
+    try {
+      setSavingEdit(true);
+      await updateHolding(portfolioId, editingId, {
+        quantity: editQty.trim(),
+        avg_cost: editAvgCost.trim() ? editAvgCost.trim() : null,
+      });
+      cancelEdit();
+      await loadHoldings();
+    } catch (error) {
+      setEditError(error instanceof Error ? error.message : "Actualizarea a esuat.");
+    } finally {
+      setSavingEdit(false);
+    }
+  };
+
+  const onDelete = async (h: HoldingRead) => {
+    setActionError("");
+    const sym = assetById.get(h.asset_id)?.symbol ?? `#${h.asset_id}`;
+    const ok = window.confirm(`Stergi detinerea pentru ${sym}?`);
+    if (!ok) return;
+    try {
+      await deleteHolding(portfolioId, h.id);
+      if (editingId === h.id) cancelEdit();
+      await loadHoldings();
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Stergerea a esuat.");
+    }
+  };
+
+  if (!idValid) {
+    return (
+      <section className="card">
+        <p className="field-error">ID portofoliu invalid.</p>
+        <Link to="/portfolios">Inapoi la portofolii</Link>
+      </section>
+    );
+  }
+
+  return (
+    <div className="portfolios-page">
+      <section className="card">
+        <p className="muted back-row">
+          <Link to="/portfolios">← Portofolii</Link>
+          {" · "}
+          <strong>Detineri portofoliu #{portfolioId}</strong>
+        </p>
+        <h3>Detineri (holdings)</h3>
+        <p className="muted">
+          Adauga pozitii pe active existente. Poti crea active noi din pagina{" "}
+          <Link to="/assets">Assets</Link>.
+        </p>
+
+        {needsAuth && (
+          <p className="field-error">
+            <Link to="/login">Autentifica-te</Link> pentru a gestiona detinerile.
+          </p>
+        )}
+
+        {listError && <p className="field-error">{listError}</p>}
+        {assetsError && <p className="field-error">{assetsError}</p>}
+        {actionError && <p className="field-error">{actionError}</p>}
+
+        <form className="portfolio-form" onSubmit={onCreate}>
+          <h4 className="subsection-title">Adauga detinere</h4>
+
+          <label htmlFor="asset-filter">Cauta activ (simbol / nume / tip)</label>
+          <input
+            id="asset-filter"
+            type="search"
+            value={assetFilter}
+            onChange={(e) => setAssetFilter(e.target.value)}
+            disabled={needsAuth || creating}
+            placeholder="ex: AAPL sau crypto"
+            autoComplete="off"
+          />
+
+          <label htmlFor="holding-asset">Selecteaza activ</label>
+          <select
+            id="holding-asset"
+            value={selectedAssetId}
+            onChange={(e) => setSelectedAssetId(e.target.value)}
+            disabled={needsAuth || creating || filteredAssets.length === 0}
+            className="select-block"
+            size={Math.min(8, Math.max(3, filteredAssets.length || 3))}
+          >
+            <option value="">
+              {filteredAssets.length === 0 ? "— Nu exista active (adauga din Assets)" : "— Alege un activ —"}
+            </option>
+            {filteredAssets.map((a) => (
+              <option key={a.id} value={String(a.id)}>
+                {a.symbol}
+                {a.name ? ` — ${a.name}` : ""}
+                {a.asset_type ? ` (${a.asset_type})` : ""}
+              </option>
+            ))}
+          </select>
+
+          <label htmlFor="holding-qty">Cantitate</label>
+          <input
+            id="holding-qty"
+            type="text"
+            inputMode="decimal"
+            value={newQty}
+            onChange={(e) => setNewQty(e.target.value)}
+            disabled={needsAuth || creating}
+            placeholder="0"
+          />
+
+          <label htmlFor="holding-avg">Cost mediu (optional)</label>
+          <input
+            id="holding-avg"
+            type="text"
+            inputMode="decimal"
+            value={newAvgCost}
+            onChange={(e) => setNewAvgCost(e.target.value)}
+            disabled={needsAuth || creating}
+            placeholder="0.00"
+          />
+
+          {createError && <p className="field-error">{createError}</p>}
+
+          <button type="submit" disabled={needsAuth || creating} className="btn-primary">
+            {creating ? "Se adauga..." : "Adauga detinere"}
+          </button>
+        </form>
+      </section>
+
+      {editingId !== null && (
+        <section className="card portfolio-edit-card">
+          <h4 className="subsection-title">Editeaza detinere</h4>
+          <form className="portfolio-form" onSubmit={onSaveEdit}>
+            <label htmlFor="edit-qty">Cantitate</label>
+            <input
+              id="edit-qty"
+              type="text"
+              inputMode="decimal"
+              value={editQty}
+              onChange={(e) => setEditQty(e.target.value)}
+              disabled={needsAuth || savingEdit}
+            />
+            {editError && <p className="field-error">{editError}</p>}
+
+            <label htmlFor="edit-avg">Cost mediu</label>
+            <input
+              id="edit-avg"
+              type="text"
+              inputMode="decimal"
+              value={editAvgCost}
+              onChange={(e) => setEditAvgCost(e.target.value)}
+              disabled={needsAuth || savingEdit}
+            />
+
+            <div className="form-actions">
+              <button type="submit" disabled={needsAuth || savingEdit} className="btn-primary">
+                {savingEdit ? "Se salveaza..." : "Salveaza"}
+              </button>
+              <button type="button" className="btn-secondary" onClick={cancelEdit} disabled={savingEdit}>
+                Anuleaza
+              </button>
+            </div>
+          </form>
+        </section>
+      )}
+
+      <section className="card">
+        <h4 className="subsection-title">Lista detineri</h4>
+        {loading ? (
+          <p className="muted">Se incarca...</p>
+        ) : holdings.length === 0 ? (
+          <p className="muted">Nu ai detineri in acest portofoliu.</p>
+        ) : (
+          <div className="table-wrap">
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th>Simbol</th>
+                  <th>Activ</th>
+                  <th>Cantitate</th>
+                  <th>Cost mediu</th>
+                  <th>Actualizat</th>
+                  <th aria-label="Actiuni" />
+                </tr>
+              </thead>
+              <tbody>
+                {holdings.map((h) => {
+                  const a = assetById.get(h.asset_id);
+                  return (
+                    <tr key={h.id}>
+                      <td>{a?.symbol ?? `id:${h.asset_id}`}</td>
+                      <td className="cell-muted">{a?.name ?? "—"}</td>
+                      <td>{formatDec(h.quantity)}</td>
+                      <td className="cell-muted">{formatDec(h.avg_cost)}</td>
+                      <td className="cell-muted">{formatDate(h.updated_at)}</td>
+                      <td className="cell-actions">
+                        <button
+                          type="button"
+                          className="btn-link"
+                          onClick={() => startEdit(h)}
+                          disabled={needsAuth || editingId === h.id}
+                        >
+                          Editeaza
+                        </button>
+                        <button
+                          type="button"
+                          className="btn-link danger"
+                          onClick={() => void onDelete(h)}
+                          disabled={needsAuth}
+                        >
+                          Sterge
+                        </button>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/PortfoliosPage.tsx
+++ b/frontend/src/pages/PortfoliosPage.tsx
@@ -249,6 +249,9 @@ export function PortfoliosPage() {
                     <td className="cell-muted">{p.description || "—"}</td>
                     <td className="cell-muted">{formatDate(p.updated_at)}</td>
                     <td className="cell-actions">
+                      <Link className="btn-link" to={`/portfolios/${p.id}/holdings`}>
+                        Detineri
+                      </Link>
                       <button
                         type="button"
                         className="btn-link"

--- a/frontend/src/pages/PortfoliosPage.tsx
+++ b/frontend/src/pages/PortfoliosPage.tsx
@@ -1,8 +1,278 @@
+import { useCallback, useEffect, useState } from "react";
+import type { FormEvent } from "react";
+import { Link } from "react-router-dom";
+import { getAccessToken } from "../lib/authToken";
+import {
+  createPortfolio,
+  deletePortfolio,
+  listPortfolios,
+  updatePortfolio,
+} from "../services/portfolios";
+import type { PortfolioRead } from "../types/portfolio";
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
 export function PortfoliosPage() {
+  const [items, setItems] = useState<PortfolioRead[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [listError, setListError] = useState("");
+
+  const [createName, setCreateName] = useState("");
+  const [createDescription, setCreateDescription] = useState("");
+  const [createError, setCreateError] = useState("");
+  const [creating, setCreating] = useState(false);
+
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+  const [editError, setEditError] = useState("");
+  const [savingEdit, setSavingEdit] = useState(false);
+
+  const [actionError, setActionError] = useState("");
+
+  const load = useCallback(async () => {
+    setListError("");
+    setLoading(true);
+    try {
+      const data = await listPortfolios();
+      setItems(data);
+    } catch (error) {
+      setListError(error instanceof Error ? error.message : "Nu am putut incarca portofoliile.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!getAccessToken()) {
+      setItems([]);
+      setListError("");
+      setLoading(false);
+      return;
+    }
+    void load();
+  }, [load]);
+
+  const token = getAccessToken();
+  const needsAuth = !token;
+
+  const onCreate = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setCreateError("");
+    setActionError("");
+    if (!createName.trim()) {
+      setCreateError("Numele portofoliului este obligatoriu.");
+      return;
+    }
+    try {
+      setCreating(true);
+      await createPortfolio({
+        name: createName.trim(),
+        description: createDescription.trim() || null,
+      });
+      setCreateName("");
+      setCreateDescription("");
+      await load();
+    } catch (error) {
+      setCreateError(error instanceof Error ? error.message : "Crearea a esuat.");
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const startEdit = (p: PortfolioRead) => {
+    setEditingId(p.id);
+    setEditName(p.name);
+    setEditDescription(p.description ?? "");
+    setEditError("");
+    setActionError("");
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setEditName("");
+    setEditDescription("");
+    setEditError("");
+  };
+
+  const onSaveEdit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (editingId === null) return;
+    setEditError("");
+    setActionError("");
+    if (!editName.trim()) {
+      setEditError("Numele portofoliului este obligatoriu.");
+      return;
+    }
+    try {
+      setSavingEdit(true);
+      await updatePortfolio(editingId, {
+        name: editName.trim(),
+        description: editDescription.trim() || null,
+      });
+      cancelEdit();
+      await load();
+    } catch (error) {
+      setEditError(error instanceof Error ? error.message : "Actualizarea a esuat.");
+    } finally {
+      setSavingEdit(false);
+    }
+  };
+
+  const onDelete = async (p: PortfolioRead) => {
+    setActionError("");
+    const ok = window.confirm(
+      `Stergi portofoliul „${p.name}”? Actiunea nu poate fi anulata din UI.`,
+    );
+    if (!ok) return;
+    try {
+      await deletePortfolio(p.id);
+      if (editingId === p.id) cancelEdit();
+      await load();
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Stergerea a esuat.");
+    }
+  };
+
   return (
-    <section className="card">
-      <h3>Portfolios</h3>
-      <p>Pagina pregatita pentru lista portofoliilor utilizatorului.</p>
-    </section>
+    <div className="portfolios-page">
+      <section className="card">
+        <h3>Portofolii</h3>
+        <p className="muted">
+          Creeaza, editeaza si sterge portofolii. Necesita autentificare (login).
+        </p>
+
+        {needsAuth && (
+          <p className="field-error">
+            Nu esti autentificat.{" "}
+            <Link to="/login">Mergi la login</Link> pentru a gestiona portofoliile.
+          </p>
+        )}
+
+        {listError && <p className="field-error">{listError}</p>}
+        {actionError && <p className="field-error">{actionError}</p>}
+
+        <form className="portfolio-form" onSubmit={onCreate}>
+          <h4 className="subsection-title">Creeaza portofoliu</h4>
+          <label htmlFor="portfolio-new-name">Nume</label>
+          <input
+            id="portfolio-new-name"
+            value={createName}
+            onChange={(e) => setCreateName(e.target.value)}
+            disabled={needsAuth || creating}
+            placeholder="ex: Long term"
+          />
+          {createError && <p className="field-error">{createError}</p>}
+
+          <label htmlFor="portfolio-new-desc">Descriere (optional)</label>
+          <textarea
+            id="portfolio-new-desc"
+            rows={2}
+            value={createDescription}
+            onChange={(e) => setCreateDescription(e.target.value)}
+            disabled={needsAuth || creating}
+            placeholder="Notite scurte"
+          />
+
+          <button type="submit" disabled={needsAuth || creating} className="btn-primary">
+            {creating ? "Se creeaza..." : "Adauga portofoliu"}
+          </button>
+        </form>
+      </section>
+
+      {editingId !== null && (
+        <section className="card portfolio-edit-card">
+          <h4 className="subsection-title">Editeaza portofoliu</h4>
+          <form className="portfolio-form" onSubmit={onSaveEdit}>
+            <label htmlFor="portfolio-edit-name">Nume</label>
+            <input
+              id="portfolio-edit-name"
+              value={editName}
+              onChange={(e) => setEditName(e.target.value)}
+              disabled={needsAuth || savingEdit}
+            />
+            {editError && <p className="field-error">{editError}</p>}
+
+            <label htmlFor="portfolio-edit-desc">Descriere</label>
+            <textarea
+              id="portfolio-edit-desc"
+              rows={2}
+              value={editDescription}
+              onChange={(e) => setEditDescription(e.target.value)}
+              disabled={needsAuth || savingEdit}
+            />
+
+            <div className="form-actions">
+              <button type="submit" disabled={needsAuth || savingEdit} className="btn-primary">
+                {savingEdit ? "Se salveaza..." : "Salveaza"}
+              </button>
+              <button
+                type="button"
+                className="btn-secondary"
+                onClick={cancelEdit}
+                disabled={savingEdit}
+              >
+                Anuleaza
+              </button>
+            </div>
+          </form>
+        </section>
+      )}
+
+      <section className="card">
+        <h4 className="subsection-title">Lista portofolii</h4>
+        {loading ? (
+          <p className="muted">Se incarca...</p>
+        ) : items.length === 0 ? (
+          <p className="muted">Nu ai inca portofolii. Creeaza unul mai sus.</p>
+        ) : (
+          <div className="table-wrap">
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th>Nume</th>
+                  <th>Descriere</th>
+                  <th>Actualizat</th>
+                  <th aria-label="Actiuni" />
+                </tr>
+              </thead>
+              <tbody>
+                {items.map((p) => (
+                  <tr key={p.id}>
+                    <td>{p.name}</td>
+                    <td className="cell-muted">{p.description || "—"}</td>
+                    <td className="cell-muted">{formatDate(p.updated_at)}</td>
+                    <td className="cell-actions">
+                      <button
+                        type="button"
+                        className="btn-link"
+                        onClick={() => startEdit(p)}
+                        disabled={needsAuth || editingId === p.id}
+                      >
+                        Editeaza
+                      </button>
+                      <button
+                        type="button"
+                        className="btn-link danger"
+                        onClick={() => void onDelete(p)}
+                        disabled={needsAuth}
+                      >
+                        Sterge
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
   );
 }

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import type { FormEvent } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { submitRegister } from "../services/auth";
 
 type RegisterFields = {
@@ -41,6 +41,7 @@ function validateRegister(fields: RegisterFields): RegisterErrors {
 }
 
 export function RegisterPage() {
+  const navigate = useNavigate();
   const [fields, setFields] = useState<RegisterFields>({
     fullName: "",
     email: "",
@@ -48,7 +49,7 @@ export function RegisterPage() {
     confirmPassword: "",
   });
   const [errors, setErrors] = useState<RegisterErrors>({});
-  const [statusMessage, setStatusMessage] = useState("");
+  const [apiError, setApiError] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const hasErrors = useMemo(() => Object.keys(errors).length > 0, [errors]);
@@ -57,7 +58,7 @@ export function RegisterPage() {
     event.preventDefault();
     const nextErrors = validateRegister(fields);
     setErrors(nextErrors);
-    setStatusMessage("");
+    setApiError("");
 
     if (Object.keys(nextErrors).length > 0) {
       return;
@@ -70,7 +71,9 @@ export function RegisterPage() {
         email: fields.email,
         password: fields.password,
       });
-      setStatusMessage("Formular trimis. Conectarea la backend va fi activata in pasul urmator.");
+      navigate("/login", { replace: true, state: { registered: true } });
+    } catch (error) {
+      setApiError(error instanceof Error ? error.message : "Inregistrarea a esuat.");
     } finally {
       setIsSubmitting(false);
     }
@@ -126,7 +129,7 @@ export function RegisterPage() {
         {isSubmitting ? "Se trimite..." : "Creeaza cont"}
       </button>
 
-      {statusMessage && <p className="field-success">{statusMessage}</p>}
+      {apiError && <p className="field-error">{apiError}</p>}
       {hasErrors && <p className="field-error">Corecteaza campurile marcate mai sus.</p>}
 
       <p className="auth-switch">

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,10 +1,8 @@
+import { getApiBaseUrl } from "../lib/apiBase";
 import type { HealthResponse } from "../types/health";
 
-const API_BASE_URL =
-  import.meta.env.VITE_API_BASE_URL?.toString() ?? "http://localhost:8000";
-
 export async function fetchHealth(): Promise<HealthResponse> {
-  const response = await fetch(`${API_BASE_URL}/health`);
+  const response = await fetch(`${getApiBaseUrl()}/health`);
   if (!response.ok) {
     throw new Error(`Healthcheck failed with status ${response.status}`);
   }

--- a/frontend/src/services/assets.ts
+++ b/frontend/src/services/assets.ts
@@ -1,0 +1,31 @@
+import { apiFetch } from "../lib/apiClient";
+import { readApiErrorMessage } from "../lib/apiError";
+import type { AssetCreateBody, AssetRead } from "../types/asset";
+
+export async function listAssets(params?: {
+  symbol?: string;
+  asset_type?: string;
+}): Promise<AssetRead[]> {
+  const search = new URLSearchParams();
+  if (params?.symbol) search.set("symbol", params.symbol);
+  if (params?.asset_type) search.set("asset_type", params.asset_type);
+  const q = search.toString();
+  const path = q ? `/assets/?${q}` : "/assets/";
+  const response = await apiFetch(path);
+  if (!response.ok) {
+    throw new Error(await readApiErrorMessage(response));
+  }
+  return (await response.json()) as AssetRead[];
+}
+
+export async function createAsset(body: AssetCreateBody): Promise<AssetRead> {
+  const response = await apiFetch("/assets/", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(await readApiErrorMessage(response));
+  }
+  return (await response.json()) as AssetRead;
+}

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,17 +1,38 @@
+import { getApiBaseUrl } from "../lib/apiBase";
+import { readApiErrorMessage } from "../lib/apiError";
 import type { LoginPayload, RegisterPayload } from "../types/auth";
+import type { TokenResponse } from "../types/token";
 
-function wait(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
+export async function submitLogin(payload: LoginPayload): Promise<TokenResponse> {
+  const body = new URLSearchParams();
+  body.set("username", payload.email);
+  body.set("password", payload.password);
+
+  const response = await fetch(`${getApiBaseUrl()}/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
   });
+
+  if (!response.ok) {
+    throw new Error(await readApiErrorMessage(response));
+  }
+
+  return (await response.json()) as TokenResponse;
 }
 
-export async function submitLogin(_payload: LoginPayload): Promise<void> {
-  // TODO: Inlocuieste cu apel backend: POST /auth/login
-  await wait(500);
-}
+export async function submitRegister(payload: RegisterPayload): Promise<void> {
+  const response = await fetch(`${getApiBaseUrl()}/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      email: payload.email,
+      password: payload.password,
+      full_name: payload.fullName.trim() || null,
+    }),
+  });
 
-export async function submitRegister(_payload: RegisterPayload): Promise<void> {
-  // TODO: Inlocuieste cu apel backend: POST /auth/register
-  await wait(500);
+  if (!response.ok) {
+    throw new Error(await readApiErrorMessage(response));
+  }
 }

--- a/frontend/src/services/holdings.ts
+++ b/frontend/src/services/holdings.ts
@@ -1,0 +1,52 @@
+import { apiFetch } from "../lib/apiClient";
+import { readApiErrorMessage } from "../lib/apiError";
+import type { HoldingCreateBody, HoldingRead, HoldingUpdateBody } from "../types/holding";
+
+export async function listHoldings(portfolioId: number): Promise<HoldingRead[]> {
+  const response = await apiFetch(`/portfolios/${portfolioId}/holdings/`);
+  if (!response.ok) {
+    throw new Error(await readApiErrorMessage(response));
+  }
+  return (await response.json()) as HoldingRead[];
+}
+
+export async function createHolding(
+  portfolioId: number,
+  body: HoldingCreateBody,
+): Promise<HoldingRead> {
+  const response = await apiFetch(`/portfolios/${portfolioId}/holdings/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(await readApiErrorMessage(response));
+  }
+  return (await response.json()) as HoldingRead;
+}
+
+export async function updateHolding(
+  portfolioId: number,
+  holdingId: number,
+  body: HoldingUpdateBody,
+): Promise<HoldingRead> {
+  const response = await apiFetch(`/portfolios/${portfolioId}/holdings/${holdingId}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(await readApiErrorMessage(response));
+  }
+  return (await response.json()) as HoldingRead;
+}
+
+export async function deleteHolding(portfolioId: number, holdingId: number): Promise<HoldingRead> {
+  const response = await apiFetch(`/portfolios/${portfolioId}/holdings/${holdingId}`, {
+    method: "DELETE",
+  });
+  if (!response.ok) {
+    throw new Error(await readApiErrorMessage(response));
+  }
+  return (await response.json()) as HoldingRead;
+}

--- a/frontend/src/services/portfolios.ts
+++ b/frontend/src/services/portfolios.ts
@@ -1,0 +1,52 @@
+import { apiFetch } from "../lib/apiClient";
+import { readApiErrorMessage } from "../lib/apiError";
+import type {
+  PortfolioCreateBody,
+  PortfolioRead,
+  PortfolioUpdateBody,
+} from "../types/portfolio";
+
+export async function listPortfolios(): Promise<PortfolioRead[]> {
+  const response = await apiFetch("/portfolios/");
+  if (!response.ok) {
+    throw new Error(await readApiErrorMessage(response));
+  }
+  return (await response.json()) as PortfolioRead[];
+}
+
+export async function createPortfolio(body: PortfolioCreateBody): Promise<PortfolioRead> {
+  const response = await apiFetch("/portfolios/", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(await readApiErrorMessage(response));
+  }
+  return (await response.json()) as PortfolioRead;
+}
+
+export async function updatePortfolio(
+  id: number,
+  body: PortfolioUpdateBody,
+): Promise<PortfolioRead> {
+  const response = await apiFetch(`/portfolios/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(await readApiErrorMessage(response));
+  }
+  return (await response.json()) as PortfolioRead;
+}
+
+export async function deletePortfolio(id: number): Promise<PortfolioRead> {
+  const response = await apiFetch(`/portfolios/${id}`, {
+    method: "DELETE",
+  });
+  if (!response.ok) {
+    throw new Error(await readApiErrorMessage(response));
+  }
+  return (await response.json()) as PortfolioRead;
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -192,3 +192,125 @@ body {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
+
+.muted {
+  color: #64748b;
+  margin-top: 0;
+}
+
+.subsection-title {
+  margin: 0 0 12px;
+  font-size: 1rem;
+}
+
+.portfolios-page {
+  display: grid;
+  gap: 16px;
+}
+
+.portfolio-form {
+  display: grid;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.portfolio-form label {
+  font-weight: 600;
+}
+
+.portfolio-form input,
+.portfolio-form textarea {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 10px 12px;
+  font: inherit;
+}
+
+.btn-primary {
+  justify-self: start;
+  margin-top: 4px;
+  border: none;
+  border-radius: 8px;
+  padding: 10px 16px;
+  background: #0f172a;
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn-primary:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 10px 16px;
+  background: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.data-table th,
+.data-table td {
+  border-bottom: 1px solid #e2e8f0;
+  padding: 10px 8px;
+  text-align: left;
+  vertical-align: top;
+}
+
+.data-table th {
+  color: #475569;
+  font-weight: 600;
+}
+
+.cell-muted {
+  color: #64748b;
+}
+
+.cell-actions {
+  white-space: nowrap;
+  text-align: right;
+}
+
+.btn-link {
+  border: none;
+  background: none;
+  padding: 0 8px;
+  font: inherit;
+  color: #2563eb;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.btn-link:disabled {
+  color: #94a3b8;
+  cursor: not-allowed;
+  text-decoration: none;
+}
+
+.btn-link.danger {
+  color: #b91c1c;
+}
+
+.portfolio-edit-card {
+  border-color: #93c5fd;
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -314,3 +314,50 @@ body {
 .portfolio-edit-card {
   border-color: #93c5fd;
 }
+
+a.btn-link {
+  display: inline-block;
+  border: none;
+  background: none;
+  padding: 0 8px;
+  font: inherit;
+  color: #2563eb;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.select-block {
+  width: 100%;
+  min-height: 120px;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 6px;
+  font: inherit;
+  background: #fff;
+}
+
+.filter-input {
+  width: 100%;
+  max-width: 420px;
+  margin-bottom: 12px;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 10px 12px;
+  font: inherit;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.back-row {
+  margin-top: 0;
+}

--- a/frontend/src/types/asset.ts
+++ b/frontend/src/types/asset.ts
@@ -1,0 +1,16 @@
+export type AssetRead = {
+  id: number;
+  symbol: string;
+  name: string | null;
+  asset_type: string | null;
+  currency: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AssetCreateBody = {
+  symbol: string;
+  name?: string | null;
+  asset_type?: string | null;
+  currency?: string | null;
+};

--- a/frontend/src/types/holding.ts
+++ b/frontend/src/types/holding.ts
@@ -1,0 +1,21 @@
+export type HoldingRead = {
+  id: number;
+  portfolio_id: number;
+  asset_id: number;
+  quantity: string | number;
+  avg_cost: string | number | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type HoldingCreateBody = {
+  portfolio_id: number;
+  asset_id: number;
+  quantity: string;
+  avg_cost?: string | null;
+};
+
+export type HoldingUpdateBody = {
+  quantity?: string;
+  avg_cost?: string | null;
+};

--- a/frontend/src/types/portfolio.ts
+++ b/frontend/src/types/portfolio.ts
@@ -1,0 +1,18 @@
+export type PortfolioRead = {
+  id: number;
+  name: string;
+  description: string | null;
+  owner_id: number;
+  created_at: string;
+  updated_at: string;
+};
+
+export type PortfolioCreateBody = {
+  name: string;
+  description?: string | null;
+};
+
+export type PortfolioUpdateBody = {
+  name?: string;
+  description?: string | null;
+};

--- a/frontend/src/types/token.ts
+++ b/frontend/src/types/token.ts
@@ -1,0 +1,4 @@
+export type TokenResponse = {
+  access_token: string;
+  token_type: string;
+};


### PR DESCRIPTION
Frontend: add API helpers (apiBase, apiClient, apiError, authToken), auth and portfolios services, types (portfolio, token), and styles; implement PortfoliosPage with full CRUD UX and update Login/Register pages to handle tokens, navigation and API errors. Backend: run Alembic migrations at container start, add CORS middleware for local dev origins, and add/fix migrations to ensure users.hashed_password is created. Misc: ignore JetBrains .idea in .gitignore.

Done #21 