### PR TITLE
Add portfolio valuation API & UI

### DIFF
--- a/frontend/src/pages/PortfolioHoldingsPage.tsx
+++ b/frontend/src/pages/PortfolioHoldingsPage.tsx
@@ -9,8 +9,10 @@ import {
   listHoldings,
   updateHolding,
 } from "../services/holdings";
+import { getPortfolioValuation } from "../services/portfolios";
 import type { AssetRead } from "../types/asset";
 import type { HoldingRead } from "../types/holding";
+import type { PortfolioValuationRead } from "../types/portfolio";
 
 function formatDec(v: string | number | null | undefined): string {
   if (v === null || v === undefined) return "—";
@@ -50,6 +52,9 @@ export function PortfolioHoldingsPage() {
   const [savingEdit, setSavingEdit] = useState(false);
   const [actionError, setActionError] = useState("");
 
+  const [valuation, setValuation] = useState<PortfolioValuationRead | null>(null);
+  const [valuationError, setValuationError] = useState("");
+
   const token = getAccessToken();
   const needsAuth = !token;
 
@@ -73,11 +78,23 @@ export function PortfolioHoldingsPage() {
   const loadHoldings = useCallback(async () => {
     if (!idValid || needsAuth) return;
     setListError("");
+    setValuationError("");
     setLoading(true);
     try {
       const data = await listHoldings(portfolioId);
       setHoldings(data);
+      try {
+        const v = await getPortfolioValuation(portfolioId);
+        setValuation(v);
+      } catch (ve) {
+        setValuation(null);
+        setValuationError(
+          ve instanceof Error ? ve.message : "Nu am putut incarca evaluarea portofoliului.",
+        );
+      }
     } catch (error) {
+      setHoldings([]);
+      setValuation(null);
       setListError(error instanceof Error ? error.message : "Nu am putut incarca detinerile.");
     } finally {
       setLoading(false);
@@ -329,6 +346,58 @@ export function PortfolioHoldingsPage() {
               </button>
             </div>
           </form>
+        </section>
+      )}
+
+      {!needsAuth && (
+        <section className="card">
+          <h4 className="subsection-title">Evaluare portofoliu</h4>
+          <p className="muted">
+            Raspuns din API: <code>GET /portfolios/:portfolioId/valuation</code> — ultimul pret cunoscut per
+            activ. Daca lipseste snapshot de pret in backend, coloana de status indica acest lucru.
+          </p>
+          {valuationError && <p className="field-error">{valuationError}</p>}
+          {loading && !valuation && !valuationError ? (
+            <p className="muted">Se incarca evaluarea...</p>
+          ) : valuation ? (
+            <>
+              <p className="valuation-total">
+                <strong>Valoare totala estimata:</strong> {formatDec(valuation.total_value)}
+              </p>
+              {valuation.assets.length === 0 ? (
+                <p className="muted">Nu exista detineri de evaluat.</p>
+              ) : (
+                <div className="table-wrap">
+                  <table className="data-table">
+                    <thead>
+                      <tr>
+                        <th>Simbol</th>
+                        <th>Activ</th>
+                        <th>Cantitate</th>
+                        <th>Pret</th>
+                        <th>Valoare</th>
+                        <th>Status pret</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {valuation.assets.map((row) => (
+                        <tr key={row.asset_id}>
+                          <td>{row.symbol ?? `id:${row.asset_id}`}</td>
+                          <td className="cell-muted">{row.name ?? "—"}</td>
+                          <td>{formatDec(row.quantity)}</td>
+                          <td className="cell-muted">{formatDec(row.price)}</td>
+                          <td>{formatDec(row.value)}</td>
+                          <td className="cell-muted">
+                            {row.missing_price ? "Lipseste pret" : "OK"}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </>
+          ) : null}
         </section>
       )}
 

--- a/frontend/src/services/portfolios.ts
+++ b/frontend/src/services/portfolios.ts
@@ -4,6 +4,7 @@ import type {
   PortfolioCreateBody,
   PortfolioRead,
   PortfolioUpdateBody,
+  PortfolioValuationRead,
 } from "../types/portfolio";
 
 export async function listPortfolios(): Promise<PortfolioRead[]> {
@@ -49,4 +50,12 @@ export async function deletePortfolio(id: number): Promise<PortfolioRead> {
     throw new Error(await readApiErrorMessage(response));
   }
   return (await response.json()) as PortfolioRead;
+}
+
+export async function getPortfolioValuation(portfolioId: number): Promise<PortfolioValuationRead> {
+  const response = await apiFetch(`/portfolios/${portfolioId}/valuation`);
+  if (!response.ok) {
+    throw new Error(await readApiErrorMessage(response));
+  }
+  return (await response.json()) as PortfolioValuationRead;
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -361,3 +361,8 @@ a.btn-link {
 .back-row {
   margin-top: 0;
 }
+
+.valuation-total {
+  margin: 0 0 12px;
+  font-size: 1.05rem;
+}

--- a/frontend/src/types/portfolio.ts
+++ b/frontend/src/types/portfolio.ts
@@ -16,3 +16,19 @@ export type PortfolioUpdateBody = {
   name?: string;
   description?: string | null;
 };
+
+export type ValuationAsset = {
+  asset_id: number;
+  symbol: string | null;
+  name: string | null;
+  quantity: string | number;
+  price: string | number | null;
+  value: string | number | null;
+  missing_price: boolean;
+};
+
+export type PortfolioValuationRead = {
+  portfolio_id: number;
+  total_value: string | number;
+  assets: ValuationAsset[];
+};


### PR DESCRIPTION
Fetch and display portfolio valuation alongside holdings. Introduces PortfolioValuationRead and ValuationAsset types, adds getPortfolioValuation() to services/portfolios.ts, and updates PortfolioHoldingsPage.tsx to load valuation, handle errors, and render a valuation section (table + total). Also adds a .valuation-total CSS rule. Error handling ensures valuation state is cleared on failures and shows localized messages.

Done #23 