### PR TITLE
Add PageStates components and update pages

### DIFF
--- a/frontend/src/components/feedback/PageStates.tsx
+++ b/frontend/src/components/feedback/PageStates.tsx
@@ -1,0 +1,48 @@
+import type { PropsWithChildren } from "react";
+
+type LoadingNoticeProps = {
+  label?: string;
+  className?: string;
+};
+
+export function LoadingNotice({
+  label = "Se incarca datele...",
+  className = "",
+}: LoadingNoticeProps) {
+  return (
+    <div className={`loading-notice ${className}`.trim()} role="status" aria-live="polite">
+      <span className="loading-spinner" aria-hidden />
+      <span className="loading-notice-text">{label}</span>
+    </div>
+  );
+}
+
+type ErrorBannerProps = {
+  message: string;
+  title?: string;
+};
+
+export function ErrorBanner({ message, title = "Eroare" }: ErrorBannerProps) {
+  if (!message) return null;
+  return (
+    <div className="error-banner" role="alert">
+      <strong className="error-banner-title">{title}</strong>
+      <p className="error-banner-body">{message}</p>
+    </div>
+  );
+}
+
+type EmptyStateProps = PropsWithChildren<{
+  title: string;
+  description?: string;
+}>;
+
+export function EmptyState({ title, description, children }: EmptyStateProps) {
+  return (
+    <div className="empty-state">
+      <h4 className="empty-state-title">{title}</h4>
+      {description ? <p className="empty-state-desc">{description}</p> : null}
+      {children ? <div className="empty-state-actions">{children}</div> : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/AssetsPage.tsx
+++ b/frontend/src/pages/AssetsPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { FormEvent } from "react";
 import { Link } from "react-router-dom";
+import { EmptyState, ErrorBanner, LoadingNotice } from "../components/feedback/PageStates";
 import { getAccessToken } from "../lib/authToken";
 import { createAsset, listAssets } from "../services/assets";
 import type { AssetRead } from "../types/asset";
@@ -101,12 +102,13 @@ export function AssetsPage() {
         </p>
 
         {needsAuth && (
-          <p className="field-error">
-            <Link to="/login">Autentifica-te</Link> pentru a gestiona activele.
-          </p>
+          <ErrorBanner
+            title="Autentificare necesara"
+            message="Catalogul de active este disponibil dupa login."
+          />
         )}
 
-        {listError && <p className="field-error">{listError}</p>}
+        {listError && <ErrorBanner title="Lista active" message={listError} />}
 
         <form className="portfolio-form" onSubmit={onCreate}>
           <h4 className="subsection-title">Adauga activ</h4>
@@ -168,9 +170,28 @@ export function AssetsPage() {
         />
 
         {loading ? (
-          <p className="muted">Se incarca...</p>
+          <LoadingNotice label="Incarcare active din API..." />
+        ) : needsAuth ? (
+          <EmptyState
+            title="Catalog indisponibil"
+            description="Autentifica-te pentru a incarca si gestiona activele."
+          >
+            <Link className="btn-link" to="/login">
+              Login
+            </Link>
+          </EmptyState>
         ) : filtered.length === 0 ? (
-          <p className="muted">{items.length === 0 ? "Nu exista inca active." : "Niciun rezultat la filtru."}</p>
+          items.length === 0 ? (
+            <EmptyState
+              title="Niciun activ in catalog"
+              description="Adauga un simbol (ex. AAPL) folosind formularul de mai sus. Activele sunt partajate pentru toate portofoliile."
+            />
+          ) : (
+            <EmptyState
+              title="Niciun rezultat"
+              description="Incearca alt termen de cautare sau sterge filtrul."
+            />
+          )
         ) : (
           <div className="table-wrap">
             <table className="data-table">

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { ErrorBanner, LoadingNotice } from "../components/feedback/PageStates";
 import { fetchHealth } from "../services/api";
 import type { HealthResponse } from "../types/health";
 
@@ -36,15 +37,22 @@ export function HomePage() {
       </p>
 
       <div className="status">
-        <strong>Backend status:</strong>
-        {requestStatus === "loading" && <span> Verific conexiunea...</span>}
-        {requestStatus === "success" && (
-          <span>
-            {" "}
-            OK ({health?.status}) | debug: {String(health?.debug)}
-          </span>
+        <strong>Backend status</strong>
+        {requestStatus === "loading" && (
+          <LoadingNotice label="Verific conexiunea cu serverul..." className="status-loading" />
         )}
-        {requestStatus === "error" && <span> Eroare: {errorMessage}</span>}
+        {requestStatus === "success" && (
+          <p className="status-ok muted">
+            Conexiune OK — status: <code>{health?.status}</code>, debug:{" "}
+            <code>{String(health?.debug)}</code>
+          </p>
+        )}
+        {requestStatus === "error" && (
+          <ErrorBanner
+            title="Nu s-a putut contacta backend-ul"
+            message={errorMessage || "Verifica daca API-ul ruleaza si URL-ul din .env (VITE_API_BASE_URL)."}
+          />
+        )}
       </div>
     </section>
   );

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import type { FormEvent } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
+import { ErrorBanner } from "../components/feedback/PageStates";
 import { setAccessToken } from "../lib/authToken";
 import { submitLogin } from "../services/auth";
 
@@ -68,7 +69,12 @@ export function LoginPage() {
   };
 
   return (
-    <form className="auth-form" onSubmit={onSubmit} noValidate>
+    <form
+      className="auth-form"
+      onSubmit={onSubmit}
+      noValidate
+      aria-busy={isSubmitting}
+    >
       <h2>Login</h2>
 
       {registered && (
@@ -100,7 +106,7 @@ export function LoginPage() {
       </button>
 
       {statusMessage && <p className="field-success">{statusMessage}</p>}
-      {apiError && <p className="field-error">{apiError}</p>}
+      {apiError && <ErrorBanner title="Autentificare esuata" message={apiError} />}
       {hasErrors && <p className="field-error">Corecteaza campurile marcate mai sus.</p>}
 
       <p className="auth-switch">

--- a/frontend/src/pages/PortfolioHoldingsPage.tsx
+++ b/frontend/src/pages/PortfolioHoldingsPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { FormEvent } from "react";
 import { Link, useParams } from "react-router-dom";
+import { EmptyState, ErrorBanner, LoadingNotice } from "../components/feedback/PageStates";
 import { getAccessToken } from "../lib/authToken";
 import { listAssets } from "../services/assets";
 import {
@@ -217,8 +218,10 @@ export function PortfolioHoldingsPage() {
   if (!idValid) {
     return (
       <section className="card">
-        <p className="field-error">ID portofoliu invalid.</p>
-        <Link to="/portfolios">Inapoi la portofolii</Link>
+        <ErrorBanner title="Ruta invalida" message="ID-ul portofoliului din URL nu este valid." />
+        <Link className="btn-link" to="/portfolios">
+          Inapoi la portofolii
+        </Link>
       </section>
     );
   }
@@ -238,14 +241,15 @@ export function PortfolioHoldingsPage() {
         </p>
 
         {needsAuth && (
-          <p className="field-error">
-            <Link to="/login">Autentifica-te</Link> pentru a gestiona detinerile.
-          </p>
+          <ErrorBanner
+            title="Autentificare necesara"
+            message="Detinerile se incarca si salveaza doar dupa login."
+          />
         )}
 
-        {listError && <p className="field-error">{listError}</p>}
-        {assetsError && <p className="field-error">{assetsError}</p>}
-        {actionError && <p className="field-error">{actionError}</p>}
+        {listError && <ErrorBanner title="Detineri" message={listError} />}
+        {assetsError && <ErrorBanner title="Catalog active" message={assetsError} />}
+        {actionError && <ErrorBanner title="Actiune esuata" message={actionError} />}
 
         <form className="portfolio-form" onSubmit={onCreate}>
           <h4 className="subsection-title">Adauga detinere</h4>
@@ -356,16 +360,19 @@ export function PortfolioHoldingsPage() {
             Raspuns din API: <code>GET /portfolios/:portfolioId/valuation</code> — ultimul pret cunoscut per
             activ. Daca lipseste snapshot de pret in backend, coloana de status indica acest lucru.
           </p>
-          {valuationError && <p className="field-error">{valuationError}</p>}
+          {valuationError && <ErrorBanner title="Evaluare portofoliu" message={valuationError} />}
           {loading && !valuation && !valuationError ? (
-            <p className="muted">Se incarca evaluarea...</p>
+            <LoadingNotice label="Incarcare evaluare din API..." />
           ) : valuation ? (
             <>
               <p className="valuation-total">
                 <strong>Valoare totala estimata:</strong> {formatDec(valuation.total_value)}
               </p>
               {valuation.assets.length === 0 ? (
-                <p className="muted">Nu exista detineri de evaluat.</p>
+                <EmptyState
+                  title="Nimic de evaluat"
+                  description="Adauga cel putin o detinere pentru a vedea linii in evaluare."
+                />
               ) : (
                 <div className="table-wrap">
                   <table className="data-table">
@@ -404,9 +411,25 @@ export function PortfolioHoldingsPage() {
       <section className="card">
         <h4 className="subsection-title">Lista detineri</h4>
         {loading ? (
-          <p className="muted">Se incarca...</p>
+          <LoadingNotice label="Incarcare detineri din API..." />
+        ) : needsAuth ? (
+          <EmptyState
+            title="Lista indisponibila"
+            description="Autentifica-te pentru a vedea detinerile acestui portofoliu."
+          >
+            <Link className="btn-link" to="/login">
+              Login
+            </Link>
+          </EmptyState>
         ) : holdings.length === 0 ? (
-          <p className="muted">Nu ai detineri in acest portofoliu.</p>
+          <EmptyState
+            title="Nicio detinere"
+            description="Selecteaza un activ din catalog (pagina Assets), apoi adauga cantitatea mai sus."
+          >
+            <Link className="btn-link" to="/assets">
+              Deschide Assets
+            </Link>
+          </EmptyState>
         ) : (
           <div className="table-wrap">
             <table className="data-table">

--- a/frontend/src/pages/PortfoliosPage.tsx
+++ b/frontend/src/pages/PortfoliosPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import type { FormEvent } from "react";
 import { Link } from "react-router-dom";
+import { EmptyState, ErrorBanner, LoadingNotice } from "../components/feedback/PageStates";
 import { getAccessToken } from "../lib/authToken";
 import {
   createPortfolio,
@@ -149,14 +150,13 @@ export function PortfoliosPage() {
         </p>
 
         {needsAuth && (
-          <p className="field-error">
-            Nu esti autentificat.{" "}
-            <Link to="/login">Mergi la login</Link> pentru a gestiona portofoliile.
+          <p className="muted">
+            <Link to="/login">Autentifica-te</Link> pentru a salva portofolii in backend.
           </p>
         )}
 
-        {listError && <p className="field-error">{listError}</p>}
-        {actionError && <p className="field-error">{actionError}</p>}
+        {listError && <ErrorBanner title="Lista portofolii" message={listError} />}
+        {actionError && <ErrorBanner title="Actiune esuata" message={actionError} />}
 
         <form className="portfolio-form" onSubmit={onCreate}>
           <h4 className="subsection-title">Creeaza portofoliu</h4>
@@ -228,9 +228,21 @@ export function PortfoliosPage() {
       <section className="card">
         <h4 className="subsection-title">Lista portofolii</h4>
         {loading ? (
-          <p className="muted">Se incarca...</p>
+          <LoadingNotice label="Incarcare portofolii din API..." />
+        ) : needsAuth ? (
+          <EmptyState
+            title="Lista indisponibila"
+            description="După autentificare, portofoliile tale vor aparea aici."
+          >
+            <Link className="btn-link" to="/login">
+              Mergi la login
+            </Link>
+          </EmptyState>
         ) : items.length === 0 ? (
-          <p className="muted">Nu ai inca portofolii. Creeaza unul mai sus.</p>
+          <EmptyState
+            title="Niciun portofoliu inca"
+            description="Foloseste formularul de mai sus pentru a crea primul portofoliu. Datele sunt salvate in backend."
+          />
         ) : (
           <div className="table-wrap">
             <table className="data-table">

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import type { FormEvent } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { ErrorBanner } from "../components/feedback/PageStates";
 import { submitRegister } from "../services/auth";
 
 type RegisterFields = {
@@ -80,7 +81,12 @@ export function RegisterPage() {
   };
 
   return (
-    <form className="auth-form" onSubmit={onSubmit} noValidate>
+    <form
+      className="auth-form"
+      onSubmit={onSubmit}
+      noValidate
+      aria-busy={isSubmitting}
+    >
       <h2>Register</h2>
 
       <label htmlFor="register-name">Nume complet</label>
@@ -129,7 +135,7 @@ export function RegisterPage() {
         {isSubmitting ? "Se trimite..." : "Creeaza cont"}
       </button>
 
-      {apiError && <p className="field-error">{apiError}</p>}
+      {apiError && <ErrorBanner title="Inregistrare esuata" message={apiError} />}
       {hasErrors && <p className="field-error">Corecteaza campurile marcate mai sus.</p>}
 
       <p className="auth-switch">

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,8 +1,48 @@
+import { Link } from "react-router-dom";
+import { EmptyState, ErrorBanner } from "../components/feedback/PageStates";
+import { getAccessToken } from "../lib/authToken";
+
 export function SettingsPage() {
+  const token = getAccessToken();
+  const needsAuth = !token;
+
   return (
-    <section className="card">
-      <h3>Settings</h3>
-      <p>Pagina pregatita pentru preferintele utilizatorului.</p>
-    </section>
+    <div className="portfolios-page">
+      <section className="card">
+        <h3>Settings</h3>
+        <p className="muted">
+          Preferinte si cont. Autentificarea se gestioneaza prin token salvat local in browser.
+        </p>
+
+        {needsAuth ? (
+          <>
+            <ErrorBanner
+              title="Nu esti autentificat"
+              message="Setarile legate de cont vor fi disponibile dupa login."
+            />
+            <EmptyState
+              title="Sesiune lipsa"
+              description="Pentru o experienta completa, autentifica-te si revino aici."
+            >
+              <Link className="btn-link" to="/login">
+                Mergi la login
+              </Link>
+            </EmptyState>
+          </>
+        ) : (
+          <EmptyState
+            title="Preferinte in dezvoltare"
+            description="Momentan nu exista optiuni configurabile in UI. Esti autentificat; poti folosi portofoliile si activele din meniu."
+          >
+            <Link className="btn-link" to="/portfolios">
+              Portofolii
+            </Link>
+            <Link className="btn-link" to="/assets">
+              Assets
+            </Link>
+          </EmptyState>
+        )}
+      </section>
+    </div>
   );
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -179,6 +179,14 @@ body {
   border-top: 1px solid #e2e8f0;
 }
 
+.status .status-loading {
+  padding: 8px 0 0;
+}
+
+.status-ok {
+  margin-top: 8px;
+}
+
 @media (max-width: 900px) {
   .dashboard-shell {
     grid-template-columns: 1fr;
@@ -365,4 +373,81 @@ a.btn-link {
 .valuation-total {
   margin: 0 0 12px;
   font-size: 1.05rem;
+}
+
+.loading-notice {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 0;
+  color: #475569;
+}
+
+.loading-spinner {
+  width: 22px;
+  height: 22px;
+  border: 3px solid #e2e8f0;
+  border-top-color: #0f172a;
+  border-radius: 50%;
+  animation: loading-spin 0.75s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.loading-notice-text {
+  font-size: 0.95rem;
+}
+
+.error-banner {
+  border: 1px solid #fecaca;
+  background: #fef2f2;
+  border-radius: 10px;
+  padding: 12px 14px;
+  margin: 12px 0;
+  color: #7f1d1d;
+}
+
+.error-banner-title {
+  display: block;
+  font-size: 0.9rem;
+  margin: 0 0 4px;
+}
+
+.error-banner-body {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.4;
+}
+
+.empty-state {
+  padding: 24px 16px;
+  text-align: center;
+  border: 1px dashed #cbd5e1;
+  border-radius: 12px;
+  background: #f8fafc;
+}
+
+.empty-state-title {
+  margin: 0 0 8px;
+  font-size: 1rem;
+  color: #0f172a;
+}
+
+.empty-state-desc {
+  margin: 0 0 12px;
+  color: #64748b;
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.empty-state-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
 }


### PR DESCRIPTION
Introduce a new feedback component file (LoadingNotice, ErrorBanner, EmptyState) at frontend/src/components/feedback/PageStates.tsx and centralize common UI states. Replace scattered inline loading, error and empty messages across multiple pages (AssetsPage, HomePage, LoginPage, PortfolioHoldingsPage, PortfoliosPage, RegisterPage, SettingsPage) to use these components, improving consistency and accessibility (added aria-busy and proper roles). Also add corresponding styles and small status layout tweaks in frontend/src/styles/global.css.

Done #24 