### PR TITLE
Add price refresh, session expiry handling & UI tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ env/
 ENV/
 .DS_Store
 /.specstory
+.vscode/settings.json

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,4 @@
 fastapi>=0.95.0
-# Keep FastAPI pinned to the version range validated with this backend's Pydantic v2 setup.
-fastapi>=0.110,<1.0
 uvicorn[standard]>=0.18.0
 pydantic>=1.10,<2.0
 python-dotenv>=1.0.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,6 @@
 fastapi>=0.95.0
+# Keep FastAPI pinned to the version range validated with this backend's Pydantic v2 setup.
+fastapi>=0.110,<1.0
 uvicorn[standard]>=0.18.0
 pydantic>=1.10,<2.0
 python-dotenv>=1.0.0

--- a/backend/schemas/portfolio.py
+++ b/backend/schemas/portfolio.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional, List
+from typing import Optional, List, Literal
 
 from pydantic import BaseModel, Field
 from decimal import Decimal
@@ -46,5 +46,21 @@ class PortfolioValuationRead(BaseModel):
     total_value: Decimal
     assets: List[ValuationAsset]
 
+<<<<<<< Updated upstream
     class Config:
         orm_mode = False
+=======
+
+class PortfolioRefreshResult(BaseModel):
+    asset_id: int
+    symbol: Optional[str]
+    status: Literal["success", "failed", "missing_symbol", "provider_error"]
+    price: Optional[Decimal]
+    timestamp: Optional[datetime]
+    message: Optional[str] = None
+
+
+class PortfolioRefreshResponse(BaseModel):
+    portfolio_id: int
+    results: List[PortfolioRefreshResult]
+>>>>>>> Stashed changes

--- a/backend/schemas/portfolio.py
+++ b/backend/schemas/portfolio.py
@@ -46,10 +46,9 @@ class PortfolioValuationRead(BaseModel):
     total_value: Decimal
     assets: List[ValuationAsset]
 
-<<<<<<< Updated upstream
     class Config:
         orm_mode = False
-=======
+
 
 class PortfolioRefreshResult(BaseModel):
     asset_id: int
@@ -63,4 +62,3 @@ class PortfolioRefreshResult(BaseModel):
 class PortfolioRefreshResponse(BaseModel):
     portfolio_id: int
     results: List[PortfolioRefreshResult]
->>>>>>> Stashed changes

--- a/frontend/src/components/layout/DashboardLayout.tsx
+++ b/frontend/src/components/layout/DashboardLayout.tsx
@@ -1,7 +1,19 @@
-import { Outlet } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { Outlet, useNavigate } from "react-router-dom";
+import { onSessionExpired } from "../../lib/sessionExpiry";
 import { MainNavigation } from "../navigation/MainNavigation";
 
 export function DashboardLayout() {
+  const navigate = useNavigate();
+  const [showSessionPopup, setShowSessionPopup] = useState(false);
+
+  useEffect(() => {
+    return onSessionExpired(() => {
+      setShowSessionPopup(true);
+      navigate("/login");
+    });
+  }, [navigate]);
+
   return (
     <div className="dashboard-shell">
       <aside className="dashboard-sidebar">
@@ -21,6 +33,17 @@ export function DashboardLayout() {
           <Outlet />
         </main>
       </div>
+      {showSessionPopup && (
+        <div className="session-modal-backdrop" role="presentation">
+          <div className="session-modal" role="alertdialog" aria-labelledby="session-expired-title">
+            <h3 id="session-expired-title">Sesiune expirata</h3>
+            <p>Ai fost deconectat automat. Te rugam sa te autentifici din nou.</p>
+            <button type="button" className="btn-primary" onClick={() => setShowSessionPopup(false)}>
+              Am inteles
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/navigation/MainNavigation.tsx
+++ b/frontend/src/components/navigation/MainNavigation.tsx
@@ -1,4 +1,6 @@
-import { NavLink } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { NavLink, useLocation, useNavigate } from "react-router-dom";
+import { clearAccessToken, getAccessToken } from "../../lib/authToken";
 
 const navItems = [
   { to: "/", label: "Overview", end: true },
@@ -8,6 +10,20 @@ const navItems = [
 ];
 
 export function MainNavigation() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [hasToken, setHasToken] = useState(Boolean(getAccessToken()));
+
+  useEffect(() => {
+    setHasToken(Boolean(getAccessToken()));
+  }, [location.pathname]);
+
+  function onLogout() {
+    clearAccessToken();
+    setHasToken(false);
+    navigate("/login");
+  }
+
   return (
     <nav aria-label="Main navigation">
       <ul className="nav-list">
@@ -22,6 +38,19 @@ export function MainNavigation() {
             </NavLink>
           </li>
         ))}
+        {hasToken ? (
+          <li className="nav-list-auth">
+            <button type="button" className="nav-link nav-button" onClick={onLogout}>
+              Logout
+            </button>
+          </li>
+        ) : (
+          <li className="nav-list-auth">
+            <NavLink to="/login" className={({ isActive }) => (isActive ? "nav-link active" : "nav-link")}>
+              Login
+            </NavLink>
+          </li>
+        )}
       </ul>
     </nav>
   );

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -1,5 +1,6 @@
-import { getAccessToken } from "./authToken";
+import { clearAccessToken, getAccessToken } from "./authToken";
 import { getApiBaseUrl } from "./apiBase";
+import { notifySessionExpired } from "./sessionExpiry";
 
 export type ApiFetchOptions = RequestInit & {
   auth?: boolean;
@@ -8,16 +9,25 @@ export type ApiFetchOptions = RequestInit & {
 export async function apiFetch(path: string, options: ApiFetchOptions = {}): Promise<Response> {
   const { auth = true, headers: initHeaders, ...rest } = options;
   const headers = new Headers(initHeaders);
+  let hadToken = false;
 
   if (auth) {
     const token = getAccessToken();
     if (token) {
+      hadToken = true;
       headers.set("Authorization", `Bearer ${token}`);
     }
   }
 
-  return fetch(`${getApiBaseUrl()}${path}`, {
+  const response = await fetch(`${getApiBaseUrl()}${path}`, {
     ...rest,
     headers,
   });
+
+  if (auth && hadToken && (response.status === 401 || response.status === 403)) {
+    clearAccessToken();
+    notifySessionExpired();
+  }
+
+  return response;
 }

--- a/frontend/src/lib/sessionExpiry.ts
+++ b/frontend/src/lib/sessionExpiry.ts
@@ -1,0 +1,11 @@
+const SESSION_EXPIRED_EVENT = "portfolio-tracker:session-expired";
+
+export function notifySessionExpired(): void {
+  window.dispatchEvent(new CustomEvent(SESSION_EXPIRED_EVENT));
+}
+
+export function onSessionExpired(handler: () => void): () => void {
+  const wrapped = () => handler();
+  window.addEventListener(SESSION_EXPIRED_EVENT, wrapped);
+  return () => window.removeEventListener(SESSION_EXPIRED_EVENT, wrapped);
+}

--- a/frontend/src/pages/PortfolioHoldingsPage.tsx
+++ b/frontend/src/pages/PortfolioHoldingsPage.tsx
@@ -10,10 +10,10 @@ import {
   listHoldings,
   updateHolding,
 } from "../services/holdings";
-import { getPortfolioValuation } from "../services/portfolios";
+import { getPortfolioValuation, refreshPortfolioPrices } from "../services/portfolios";
 import type { AssetRead } from "../types/asset";
 import type { HoldingRead } from "../types/holding";
-import type { PortfolioValuationRead } from "../types/portfolio";
+import type { PortfolioRefreshResponse, PortfolioValuationRead } from "../types/portfolio";
 
 function formatDec(v: string | number | null | undefined): string {
   if (v === null || v === undefined) return "—";
@@ -55,6 +55,10 @@ export function PortfolioHoldingsPage() {
 
   const [valuation, setValuation] = useState<PortfolioValuationRead | null>(null);
   const [valuationError, setValuationError] = useState("");
+  const [refreshingPrices, setRefreshingPrices] = useState(false);
+  const [refreshError, setRefreshError] = useState("");
+  const [refreshSuccess, setRefreshSuccess] = useState("");
+  const [lastRefresh, setLastRefresh] = useState<PortfolioRefreshResponse | null>(null);
 
   const token = getAccessToken();
   const needsAuth = !token;
@@ -215,6 +219,43 @@ export function PortfolioHoldingsPage() {
     }
   };
 
+  const onRefreshPrices = async () => {
+    if (needsAuth || refreshingPrices || !idValid) return;
+    setRefreshError("");
+    setRefreshSuccess("");
+    setValuationError("");
+    try {
+      setRefreshingPrices(true);
+      const refreshResult = await refreshPortfolioPrices(portfolioId);
+      setLastRefresh(refreshResult);
+      const okCount = refreshResult.results.filter((r) => r.status === "success").length;
+      const failCount = refreshResult.results.length - okCount;
+      setRefreshSuccess(
+        failCount === 0
+          ? `Preturile au fost actualizate pentru ${okCount} active.`
+          : `Refresh finalizat: ${okCount} active actualizate, ${failCount} cu probleme.`,
+      );
+
+      const nextValuation = await getPortfolioValuation(portfolioId);
+      setValuation(nextValuation);
+    } catch (error) {
+      setRefreshError(error instanceof Error ? error.message : "Nu am putut face refresh la preturi.");
+      try {
+        const fallbackValuation = await getPortfolioValuation(portfolioId);
+        setValuation(fallbackValuation);
+      } catch (valuationLoadError) {
+        setValuation(null);
+        setValuationError(
+          valuationLoadError instanceof Error
+            ? valuationLoadError.message
+            : "Nu am putut reincarca evaluarea dupa refresh.",
+        );
+      }
+    } finally {
+      setRefreshingPrices(false);
+    }
+  };
+
   if (!idValid) {
     return (
       <section className="card">
@@ -272,9 +313,8 @@ export function PortfolioHoldingsPage() {
             onChange={(e) => setSelectedAssetId(e.target.value)}
             disabled={needsAuth || creating || filteredAssets.length === 0}
             className="select-block"
-            size={Math.min(8, Math.max(3, filteredAssets.length || 3))}
           >
-            <option value="">
+            <option value="" disabled>
               {filteredAssets.length === 0 ? "— Nu exista active (adauga din Assets)" : "— Alege un activ —"}
             </option>
             {filteredAssets.map((a) => (
@@ -285,6 +325,9 @@ export function PortfolioHoldingsPage() {
               </option>
             ))}
           </select>
+          {selectedAssetId ? (
+            <p className="muted">Activ selectat: {assetById.get(Number(selectedAssetId))?.symbol ?? selectedAssetId}</p>
+          ) : null}
 
           <label htmlFor="holding-qty">Cantitate</label>
           <input
@@ -360,6 +403,28 @@ export function PortfolioHoldingsPage() {
             Raspuns din API: <code>GET /portfolios/:portfolioId/valuation</code> — ultimul pret cunoscut per
             activ. Daca lipseste snapshot de pret in backend, coloana de status indica acest lucru.
           </p>
+          <div className="form-actions">
+            <button
+              type="button"
+              className="btn-secondary"
+              onClick={() => void onRefreshPrices()}
+              disabled={refreshingPrices || loading}
+            >
+              {refreshingPrices ? "Refresh in curs..." : "Refresh Prices"}
+            </button>
+          </div>
+          {refreshingPrices && <LoadingNotice label="Se cer preturi live si se recalculeaza evaluarea..." />}
+          {refreshError && <ErrorBanner title="Refresh prices esuat" message={refreshError} />}
+          {refreshSuccess && <p className="field-success">{refreshSuccess}</p>}
+          {lastRefresh && lastRefresh.results.some((row) => row.status !== "success") ? (
+            <ErrorBanner
+              title="Unele preturi nu au putut fi actualizate"
+              message={lastRefresh.results
+                .filter((row) => row.status !== "success")
+                .map((row) => `${row.symbol ?? `id:${row.asset_id}`}: ${row.status}`)
+                .join(" | ")}
+            />
+          ) : null}
           {valuationError && <ErrorBanner title="Evaluare portofoliu" message={valuationError} />}
           {loading && !valuation && !valuationError ? (
             <LoadingNotice label="Incarcare evaluare din API..." />
@@ -374,34 +439,57 @@ export function PortfolioHoldingsPage() {
                   description="Adauga cel putin o detinere pentru a vedea linii in evaluare."
                 />
               ) : (
-                <div className="table-wrap">
-                  <table className="data-table">
-                    <thead>
-                      <tr>
-                        <th>Simbol</th>
-                        <th>Activ</th>
-                        <th>Cantitate</th>
-                        <th>Pret</th>
-                        <th>Valoare</th>
-                        <th>Status pret</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {valuation.assets.map((row) => (
-                        <tr key={row.asset_id}>
-                          <td>{row.symbol ?? `id:${row.asset_id}`}</td>
-                          <td className="cell-muted">{row.name ?? "—"}</td>
-                          <td>{formatDec(row.quantity)}</td>
-                          <td className="cell-muted">{formatDec(row.price)}</td>
-                          <td>{formatDec(row.value)}</td>
-                          <td className="cell-muted">
-                            {row.missing_price ? "Lipseste pret" : "OK"}
-                          </td>
+                <>
+                  <div className="table-wrap">
+                    <table className="data-table">
+                      <thead>
+                        <tr>
+                          <th>Simbol</th>
+                          <th>Activ</th>
+                          <th>Cantitate</th>
+                          <th>Pret</th>
+                          <th>Valoare</th>
+                          <th>Status pret</th>
                         </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
+                      </thead>
+                      <tbody>
+                        {valuation.assets.map((row, idx) => (
+                          <tr key={`${row.asset_id}-${idx}`}>
+                            <td>{row.symbol ?? `id:${row.asset_id}`}</td>
+                            <td className="cell-muted">{row.name ?? "—"}</td>
+                            <td>{formatDec(row.quantity)}</td>
+                            <td className="cell-muted">{formatDec(row.price)}</td>
+                            <td>{formatDec(row.value)}</td>
+                            <td className="cell-muted">
+                              {row.missing_price ? "Lipseste pret" : "OK"}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+
+                  {lastRefresh ? (
+                    (() => {
+                      const missingAfterRefresh = valuation.assets.filter((row) => row.missing_price);
+                      if (missingAfterRefresh.length === 0) {
+                        return <p className="field-success">Dupa refresh, toate detinerile au pret disponibil.</p>;
+                      }
+                      return (
+                        <div className="error-banner" role="status" aria-live="polite">
+                          <strong className="error-banner-title">
+                            Dupa refresh, inca lipsesc preturi pentru {missingAfterRefresh.length} detineri
+                          </strong>
+                          <p className="error-banner-body">
+                            {missingAfterRefresh
+                              .map((row) => row.symbol ?? row.name ?? `id:${row.asset_id}`)
+                              .join(", ")}
+                          </p>
+                        </div>
+                      );
+                    })()
+                  ) : null}
+                </>
               )}
             </>
           ) : null}

--- a/frontend/src/pages/PortfoliosPage.tsx
+++ b/frontend/src/pages/PortfoliosPage.tsx
@@ -6,6 +6,8 @@ import { getAccessToken } from "../lib/authToken";
 import {
   createPortfolio,
   deletePortfolio,
+  getPortfolioDetail,
+  getPortfolioValuation,
   listPortfolios,
   updatePortfolio,
 } from "../services/portfolios";
@@ -20,7 +22,17 @@ function formatDate(iso: string): string {
 }
 
 export function PortfoliosPage() {
+  type PortfolioOverview = {
+    holdingCount: number | null;
+    estimatedValue: string | number | null;
+    missingPriceCount: number | null;
+    warning: string | null;
+  };
+
   const [items, setItems] = useState<PortfolioRead[]>([]);
+  const [overviewById, setOverviewById] = useState<Record<number, PortfolioOverview>>({});
+  const [overviewLoading, setOverviewLoading] = useState(false);
+  const [overviewError, setOverviewError] = useState("");
   const [loading, setLoading] = useState(true);
   const [listError, setListError] = useState("");
 
@@ -43,9 +55,54 @@ export function PortfoliosPage() {
     try {
       const data = await listPortfolios();
       setItems(data);
+      setOverviewError("");
+      setOverviewById({});
+      if (data.length > 0) {
+        setOverviewLoading(true);
+        const overviewEntries = await Promise.all(
+          data.map(async (portfolio) => {
+            try {
+              const [detail, valuation] = await Promise.all([
+                getPortfolioDetail(portfolio.id),
+                getPortfolioValuation(portfolio.id),
+              ]);
+              const missingPriceCount = valuation.assets.filter((asset) => asset.missing_price).length;
+              return [
+                portfolio.id,
+                {
+                  holdingCount: detail.holdings.length,
+                  estimatedValue: valuation.total_value,
+                  missingPriceCount,
+                  warning:
+                    missingPriceCount > 0
+                      ? `${missingPriceCount} ${missingPriceCount === 1 ? "pret lipsa" : "preturi lipsa"}`
+                      : null,
+                } satisfies PortfolioOverview,
+              ] as const;
+            } catch (error) {
+              return [
+                portfolio.id,
+                {
+                  holdingCount: null,
+                  estimatedValue: null,
+                  missingPriceCount: null,
+                  warning: error instanceof Error ? error.message : "Nu am putut incarca overview-ul.",
+                } satisfies PortfolioOverview,
+              ] as const;
+            }
+          }),
+        );
+        setOverviewById(Object.fromEntries(overviewEntries));
+        if (overviewEntries.some(([, v]) => v.warning)) {
+          setOverviewError(
+            "Unele overview-uri nu sunt complete. Verifica detaliile din coloana Status pret.",
+          );
+        }
+      }
     } catch (error) {
       setListError(error instanceof Error ? error.message : "Nu am putut incarca portofoliile.");
     } finally {
+      setOverviewLoading(false);
       setLoading(false);
     }
   }, []);
@@ -156,6 +213,7 @@ export function PortfoliosPage() {
         )}
 
         {listError && <ErrorBanner title="Lista portofolii" message={listError} />}
+        {overviewError && <ErrorBanner title="Overview portofolii" message={overviewError} />}
         {actionError && <ErrorBanner title="Actiune esuata" message={actionError} />}
 
         <form className="portfolio-form" onSubmit={onCreate}>
@@ -250,6 +308,9 @@ export function PortfoliosPage() {
                 <tr>
                   <th>Nume</th>
                   <th>Descriere</th>
+                  <th>Detineri</th>
+                  <th>Valoare estimata</th>
+                  <th>Status pret</th>
                   <th>Actualizat</th>
                   <th aria-label="Actiuni" />
                 </tr>
@@ -257,8 +318,21 @@ export function PortfoliosPage() {
               <tbody>
                 {items.map((p) => (
                   <tr key={p.id}>
+                    {(() => {
+                      const overview = overviewById[p.id];
+                      return (
+                        <>
                     <td>{p.name}</td>
                     <td className="cell-muted">{p.description || "—"}</td>
+                    <td className="cell-muted">
+                      {overviewLoading && !overview ? "Se calculeaza..." : overview?.holdingCount ?? "—"}
+                    </td>
+                    <td>{overviewLoading && !overview ? "Se calculeaza..." : overview?.estimatedValue ?? "—"}</td>
+                    <td className={overview?.missingPriceCount ? "cell-warning" : "cell-muted"}>
+                      {overviewLoading && !overview
+                        ? "Se verifica..."
+                        : overview?.warning ?? "Preturi complete"}
+                    </td>
                     <td className="cell-muted">{formatDate(p.updated_at)}</td>
                     <td className="cell-actions">
                       <Link className="btn-link" to={`/portfolios/${p.id}/holdings`}>
@@ -281,6 +355,9 @@ export function PortfoliosPage() {
                         Sterge
                       </button>
                     </td>
+                        </>
+                      );
+                    })()}
                   </tr>
                 ))}
               </tbody>

--- a/frontend/src/services/portfolios.ts
+++ b/frontend/src/services/portfolios.ts
@@ -2,6 +2,7 @@ import { apiFetch } from "../lib/apiClient";
 import { readApiErrorMessage } from "../lib/apiError";
 import type {
   PortfolioCreateBody,
+  PortfolioDetailRead,
   PortfolioRefreshResponse,
   PortfolioRead,
   PortfolioUpdateBody,
@@ -59,6 +60,14 @@ export async function getPortfolioValuation(portfolioId: number): Promise<Portfo
     throw new Error(await readApiErrorMessage(response));
   }
   return (await response.json()) as PortfolioValuationRead;
+}
+
+export async function getPortfolioDetail(portfolioId: number): Promise<PortfolioDetailRead> {
+  const response = await apiFetch(`/portfolios/${portfolioId}`);
+  if (!response.ok) {
+    throw new Error(await readApiErrorMessage(response));
+  }
+  return (await response.json()) as PortfolioDetailRead;
 }
 
 export async function refreshPortfolioPrices(portfolioId: number): Promise<PortfolioRefreshResponse> {

--- a/frontend/src/services/portfolios.ts
+++ b/frontend/src/services/portfolios.ts
@@ -2,6 +2,7 @@ import { apiFetch } from "../lib/apiClient";
 import { readApiErrorMessage } from "../lib/apiError";
 import type {
   PortfolioCreateBody,
+  PortfolioRefreshResponse,
   PortfolioRead,
   PortfolioUpdateBody,
   PortfolioValuationRead,
@@ -58,4 +59,14 @@ export async function getPortfolioValuation(portfolioId: number): Promise<Portfo
     throw new Error(await readApiErrorMessage(response));
   }
   return (await response.json()) as PortfolioValuationRead;
+}
+
+export async function refreshPortfolioPrices(portfolioId: number): Promise<PortfolioRefreshResponse> {
+  const response = await apiFetch(`/portfolios/${portfolioId}/refresh-prices`, {
+    method: "POST",
+  });
+  if (!response.ok) {
+    throw new Error(await readApiErrorMessage(response));
+  }
+  return (await response.json()) as PortfolioRefreshResponse;
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -102,6 +102,8 @@ body {
   background: #0f172a;
   color: #e2e8f0;
   padding: 24px 16px;
+  display: flex;
+  flex-direction: column;
 }
 
 .brand h1 {
@@ -118,8 +120,10 @@ body {
   list-style: none;
   margin: 0;
   padding: 0;
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 8px;
+  min-height: calc(100vh - 150px);
 }
 
 .nav-link {
@@ -138,6 +142,20 @@ body {
 .nav-link.active {
   background: #334155;
   color: #ffffff;
+}
+
+.nav-button {
+  width: 100%;
+  border: none;
+  background: transparent;
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+}
+
+.nav-list-auth {
+  margin-top: auto;
+  padding-top: 12px;
 }
 
 .dashboard-content {
@@ -197,7 +215,12 @@ body {
   }
 
   .nav-list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    min-height: unset;
+  }
+
+  .nav-list-auth {
+    margin-top: 0;
+    padding-top: 0;
   }
 }
 
@@ -336,10 +359,10 @@ a.btn-link {
 
 .select-block {
   width: 100%;
-  min-height: 120px;
+  min-height: 42px;
   border: 1px solid #cbd5e1;
   border-radius: 8px;
-  padding: 6px;
+  padding: 10px 12px;
   font: inherit;
   background: #fff;
 }
@@ -450,4 +473,31 @@ a.btn-link {
   flex-wrap: wrap;
   gap: 8px;
   justify-content: center;
+}
+
+.session-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  display: grid;
+  place-items: center;
+  z-index: 1000;
+}
+
+.session-modal {
+  width: min(92vw, 440px);
+  background: #ffffff;
+  border: 1px solid #cbd5e1;
+  border-radius: 12px;
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.18);
+  padding: 20px;
+}
+
+.session-modal h3 {
+  margin: 0 0 8px;
+}
+
+.session-modal p {
+  margin: 0 0 14px;
+  color: #334155;
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -317,6 +317,11 @@ body {
   color: #64748b;
 }
 
+.cell-warning {
+  color: #b45309;
+  font-weight: 600;
+}
+
 .cell-actions {
   white-space: nowrap;
   text-align: right;

--- a/frontend/src/types/portfolio.ts
+++ b/frontend/src/types/portfolio.ts
@@ -7,6 +7,12 @@ export type PortfolioRead = {
   updated_at: string;
 };
 
+export type PortfolioDetailRead = PortfolioRead & {
+  holdings: Array<{
+    id: number;
+  }>;
+};
+
 export type PortfolioCreateBody = {
   name: string;
   description?: string | null;

--- a/frontend/src/types/portfolio.ts
+++ b/frontend/src/types/portfolio.ts
@@ -32,3 +32,17 @@ export type PortfolioValuationRead = {
   total_value: string | number;
   assets: ValuationAsset[];
 };
+
+export type PortfolioRefreshResult = {
+  asset_id: number;
+  symbol: string | null;
+  status: "success" | "failed" | "missing_symbol" | "provider_error" | string;
+  price: string | number | null;
+  timestamp: string | null;
+  message: string | null;
+};
+
+export type PortfolioRefreshResponse = {
+  portfolio_id: number;
+  results: PortfolioRefreshResult[];
+};


### PR DESCRIPTION
Introduce portfolio price refresh flow and session-expiry handling across the frontend. Key changes:

- frontend: add sessionExpiry utility (event dispatch/listener) and wire it into apiClient to clear tokens and notify on 401/403 responses.
- frontend: DashboardLayout listens for session expiry, redirects to /login and shows a session-expired modal; MainNavigation shows Login/Logout based on token state; auth token helpers used to manage access token.
- frontend: PortfolioHoldingsPage: add refresh-prices action, UI feedback (loading, success/failure messages, detailed error banners), update valuation after refresh, and minor form/table UX improvements.
- frontend: services/portfolios: add refreshPortfolioPrices API call; types/portfolio: add types for refresh results and response.
- frontend: global.css: layout and component style adjustments, including styles for session modal and nav auth button.
- .gitignore: ignore .vscode/settings.json


Note: backend/requirements.txt and backend/schemas/portfolio.py contain unresolved merge conflict markers (<<<<<<<, >>>>>>>) that must be resolved before merging.

done #64 